### PR TITLE
Give debug builds their own applicationId

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -44,6 +44,10 @@ android {
     }
 
     buildTypes {
+        debug {
+            applicationIdSuffix = ".debug"
+            resValue("string", "app_name", "ES-DE Companion (Debug)")
+        }
         release {
             isMinifyEnabled = true
             isShrinkResources = true

--- a/app/src/androidTest/java/com/esde/companion/ExampleInstrumentedTest.kt
+++ b/app/src/androidTest/java/com/esde/companion/ExampleInstrumentedTest.kt
@@ -17,6 +17,6 @@ class ExampleInstrumentedTest {
     fun useAppContext() {
         // Context of the app under test.
         val appContext = InstrumentationRegistry.getInstrumentation().targetContext
-        assertEquals("com.esde.companion", appContext.packageName)
+        assertEquals(BuildConfig.APPLICATION_ID, appContext.packageName)
     }
 }

--- a/app/src/main/java/com/esde/companion/ui/main/LongPressSettingsMenu.kt
+++ b/app/src/main/java/com/esde/companion/ui/main/LongPressSettingsMenu.kt
@@ -443,8 +443,9 @@ private fun SettingsMenuHome(
         // AppDock's no-op clickable - so this reads as plain text, not an obvious
         // button, keeping the Easter egg's presence undiscoverable short of trying it.
         var versionTapCount by remember { mutableIntStateOf(0) }
+        val debugSuffix = if (BuildConfig.DEBUG) " (Debug)" else ""
         Text(
-            text = "ES-DE Companion v${BuildConfig.VERSION_NAME}",
+            text = "ES-DE Companion v${BuildConfig.VERSION_NAME}$debugSuffix",
             style = MaterialTheme.typography.bodySmall,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
             textAlign = TextAlign.Center,


### PR DESCRIPTION
## Summary
- Debug builds now get `applicationIdSuffix = ".debug"` (installs as `com.esde.companion.debug`) so they install side by side with a release install instead of colliding on signature mismatch and requiring an uninstall before every reinstall.
- Debug builds get a distinct launcher label, "ES-DE Companion (Debug)", so the two are easy to tell apart.
- The main menu's version footer now shows "(Debug)" for debug builds, since that's otherwise not obvious once both are installed.
- Fixed `ExampleInstrumentedTest`'s hardcoded `"com.esde.companion"` package assertion to use `BuildConfig.APPLICATION_ID` instead, since it would otherwise fail against the suffixed debug package.

## Test plan
- [x] ktlintCheck / detekt
- [x] testDebugUnitTest
- [x] assembleDebug / assembleRelease
- [x] connectedDebugAndroidTest (on-device)
- [x] Verified on-device (AYN Thor): release + debug install side by side without uninstalling either; reinstalling debug needs no uninstall; debug build launches correctly on display 4; main menu footer reads "ES-DE Companion v1.0.4 (Debug)"