### PR TITLE
Shorten Rating widget's Show Empty Stars chip label

### DIFF
--- a/app/src/main/java/com/esde/companion/ui/widgets/edit/EditWidgetsOverlay.kt
+++ b/app/src/main/java/com/esde/companion/ui/widgets/edit/EditWidgetsOverlay.kt
@@ -1703,7 +1703,7 @@ private fun GameDescriptionConfig(
 private fun NoRatingBehavior.displayLabel(): String =
     when (this) {
         NoRatingBehavior.Hide -> "Hide Widget"
-        NoRatingBehavior.ShowEmptyStars -> "Show Empty Stars"
+        NoRatingBehavior.ShowEmptyStars -> "Show Empty"
     }
 
 @Composable


### PR DESCRIPTION
## Summary
- Changes the No Rating Behavior segmented button label from "Show Empty Stars" to "Show Empty" so it fits on one line alongside "Hide Widget", keeping both chips equally sized

## Test plan
- [x] ktlintCheck / detekt pass