### PR TITLE
Technical debt paydown: Phase 1+2 (fix !! usages, zero ktlint baseline)

### DIFF
--- a/app/src/main/java/com/esde/companion/domain/model/WidgetContentResolver.kt
+++ b/app/src/main/java/com/esde/companion/domain/model/WidgetContentResolver.kt
@@ -22,7 +22,15 @@ object WidgetContentResolver {
                     // kdoc / CLAUDE.md) - a custom logo is expected to be a similarly
                     // transparent-background image, so it uses LogoTransitionMode at
                     // render time rather than a fade.
-                    ?.let { WidgetContent.Image(it, widgetType.scaleMode, isTransparentOverlay = true, isAsset = false, effects = widgetType.effects) }
+                    ?.let {
+                        WidgetContent.Image(
+                            it,
+                            widgetType.scaleMode,
+                            isTransparentOverlay = true,
+                            isAsset = false,
+                            effects = widgetType.effects,
+                        )
+                    }
                     ?: systemLogoAssetPath()
                         ?.let { WidgetContent.SystemLogoAsset(it, widgetType.scaleMode, widgetType.effects) }
                     ?: systemNameLookup()?.let { WidgetContent.NameFallback(it) }
@@ -30,7 +38,15 @@ object WidgetContentResolver {
 
             is WidgetType.SystemImage ->
                 customSystemImageLookup()
-                    ?.let { WidgetContent.Image(it, widgetType.scaleMode, isTransparentOverlay = false, isAsset = false, effects = widgetType.effects) }
+                    ?.let {
+                        WidgetContent.Image(
+                            it,
+                            widgetType.scaleMode,
+                            isTransparentOverlay = false,
+                            isAsset = false,
+                            effects = widgetType.effects,
+                        )
+                    }
                     ?: resolveMediaWidgetContent(
                         mediaType = MediaType.FanArt,
                         scaleMode = widgetType.scaleMode,

--- a/app/src/main/java/com/esde/companion/ui/MainActivity.kt
+++ b/app/src/main/java/com/esde/companion/ui/MainActivity.kt
@@ -582,7 +582,6 @@ class MainActivity : ComponentActivity() {
                             val isBrowsingGame = (connectionState as? EsdeConnectionState.Connected)?.appState is AppState.BrowsingGame
                             val showVideoOverlay =
                                 videoPlaybackEnabled &&
-                                    videoPath != null &&
                                     isBrowsingGame &&
                                     mainScreenActive &&
                                     isActivityVisible
@@ -896,24 +895,28 @@ class MainActivity : ComponentActivity() {
                                 }
 
                                 if (showVideoOverlay) {
-                                    val resolvedVideoPath = videoPath!!
-                                    val videoPlaybackStateRepository = appContainer.videoPlaybackStateRepository
-                                    VideoOverlayScreen(
-                                        videoPath = resolvedVideoPath,
-                                        delaySeconds = videoDelaySeconds,
-                                        audioEnabled = videoAudioEnabled,
-                                        modifier = Modifier.fillMaxSize(),
-                                        onPlaybackEvent = { event ->
-                                            when (event) {
-                                                is VideoPlaybackEvent.PlayingChanged ->
-                                                    videoPlaybackStateRepository.setIsPlaying(event.isPlaying)
-                                                VideoPlaybackEvent.Started ->
-                                                    appContainer.logVideoPlaybackStarted(resolvedVideoPath)
-                                                is VideoPlaybackEvent.Error ->
-                                                    appContainer.logVideoPlaybackError(resolvedVideoPath, event.message)
-                                            }
-                                        },
-                                    )
+                                    videoPath?.let { resolvedVideoPath ->
+                                        val videoPlaybackStateRepository = appContainer.videoPlaybackStateRepository
+                                        VideoOverlayScreen(
+                                            videoPath = resolvedVideoPath,
+                                            delaySeconds = videoDelaySeconds,
+                                            audioEnabled = videoAudioEnabled,
+                                            modifier = Modifier.fillMaxSize(),
+                                            onPlaybackEvent = { event ->
+                                                when (event) {
+                                                    is VideoPlaybackEvent.PlayingChanged ->
+                                                        videoPlaybackStateRepository.setIsPlaying(event.isPlaying)
+                                                    VideoPlaybackEvent.Started ->
+                                                        appContainer.logVideoPlaybackStarted(resolvedVideoPath)
+                                                    is VideoPlaybackEvent.Error ->
+                                                        appContainer.logVideoPlaybackError(
+                                                            resolvedVideoPath,
+                                                            event.message,
+                                                        )
+                                                }
+                                            },
+                                        )
+                                    }
                                 }
 
                                 // Update checker dialogs (silent startup check + manual

--- a/app/src/main/java/com/esde/companion/ui/main/CrossfadeAsyncImage.kt
+++ b/app/src/main/java/com/esde/companion/ui/main/CrossfadeAsyncImage.kt
@@ -22,6 +22,13 @@ import coil3.imageLoader
 import coil3.request.SuccessResult
 
 /**
+ * Reproduces android.view.animation.DecelerateInterpolator's default (factor = 1.0)
+ * curve - fast start, easing into the landing point - since Compose has no built-in
+ * equivalent and the legacy Glide-based transition used it explicitly.
+ */
+private val DecelerateEasing = Easing { fraction -> 1f - (1f - fraction) * (1f - fraction) }
+
+/**
  * Crossfades from whatever model was previously shown to [model], never showing a
  * blank/partial frame.
  *
@@ -56,14 +63,6 @@ import coil3.request.SuccessResult
  * The outgoing (previous) layer stays fully opaque - since both layers are the same size,
  * a static backdrop plus a fading-in foreground already looks like a clean crossfade.
  */
-
-/**
- * Reproduces android.view.animation.DecelerateInterpolator's default (factor = 1.0)
- * curve - fast start, easing into the landing point - since Compose has no built-in
- * equivalent and the legacy Glide-based transition used it explicitly.
- */
-private val DecelerateEasing = Easing { fraction -> 1f - (1f - fraction) * (1f - fraction) }
-
 @Composable
 fun CrossfadeAsyncImage(
     model: Any?,

--- a/app/src/main/java/com/esde/companion/ui/widgets/WidgetCanvas.kt
+++ b/app/src/main/java/com/esde/companion/ui/widgets/WidgetCanvas.kt
@@ -212,7 +212,8 @@ internal fun WidgetContentView(
                 DarkenOverlay(effects = content.effects)
             }
 
-        is WidgetContent.SystemLogoAsset -> Unit // unreachable: SystemLogoAsset only occurs for SystemLogo widgetType, which isLogoStyle handles above
+        // unreachable: SystemLogoAsset only occurs for SystemLogo widgetType, which isLogoStyle handles above
+        is WidgetContent.SystemLogoAsset -> Unit
 
         is WidgetContent.NameFallback -> Unit // unreachable: only ever produced for isLogoStyle widget types, handled above
 

--- a/app/src/main/java/com/esde/companion/ui/widgets/WidgetsViewModel.kt
+++ b/app/src/main/java/com/esde/companion/ui/widgets/WidgetsViewModel.kt
@@ -203,7 +203,8 @@ class WidgetsViewModel(
                     gameMediaLookup = { mediaType -> gameMedia?.path(mediaType) },
                     gameDescriptionLookup = { gameDescription?.text },
                     gameRatingLookup = { gameRating?.value },
-                    fallbackBackgroundAssetPath = FALLBACK_BACKGROUND_ASSET, // null in EditWidgetsViewModel, as today
+                    // null in EditWidgetsViewModel, as today
+                    fallbackBackgroundAssetPath = FALLBACK_BACKGROUND_ASSET,
                     systemNameLookup = { identity.systemFullName },
                     gameNameLookup = { identity.gameName },
                 )

--- a/app/src/main/java/com/esde/companion/ui/widgets/edit/EditWidgetsOverlay.kt
+++ b/app/src/main/java/com/esde/companion/ui/widgets/edit/EditWidgetsOverlay.kt
@@ -507,7 +507,8 @@ fun EditWidgetsOverlay(
                             showAddPicker = true
                         },
                     )
-                    if (selectedWidgetId != null) {
+                    val selectedId = selectedWidgetId
+                    if (selectedId != null) {
                         DropdownMenuItem(
                             text = { Text("Configure Widget") },
                             leadingIcon = { Icon(imageVector = Icons.Filled.Settings, contentDescription = null) },
@@ -520,7 +521,7 @@ fun EditWidgetsOverlay(
                             text = { Text("Move Forwards") },
                             leadingIcon = { Icon(imageVector = Icons.Filled.FlipToFront, contentDescription = null) },
                             onClick = {
-                                viewModel.moveUp(selectedWidgetId!!)
+                                viewModel.moveUp(selectedId)
                                 menuExpanded = false
                             },
                         )
@@ -528,7 +529,7 @@ fun EditWidgetsOverlay(
                             text = { Text("Move Backwards") },
                             leadingIcon = { Icon(imageVector = Icons.Filled.FlipToBack, contentDescription = null) },
                             onClick = {
-                                viewModel.moveDown(selectedWidgetId!!)
+                                viewModel.moveDown(selectedId)
                                 menuExpanded = false
                             },
                         )
@@ -537,7 +538,7 @@ fun EditWidgetsOverlay(
                             leadingIcon = { Icon(imageVector = Icons.Filled.Delete, contentDescription = null) },
                             onClick = {
                                 hapticFeedback.performHapticFeedback(HapticFeedbackType.LongPress)
-                                viewModel.removeWidget(selectedWidgetId!!)
+                                viewModel.removeWidget(selectedId)
                                 menuExpanded = false
                             },
                         )
@@ -1560,14 +1561,22 @@ private fun GlintConfig(
  * (tint/darken behind other widgets) with a much simpler UI. */
 private val COLOR_PRESETS =
     listOf(
-        0xFF000000L, // black
-        0xFFFFFFFFL, // white
-        0xFF9E9E9EL, // gray
-        0xFFF44336L, // red
-        0xFF2196F3L, // blue
-        0xFF4CAF50L, // green
-        0xFFFFEB3BL, // yellow
-        0xFF9C27B0L, // purple
+        // black
+        0xFF000000L,
+        // white
+        0xFFFFFFFFL,
+        // gray
+        0xFF9E9E9EL,
+        // red
+        0xFFF44336L,
+        // blue
+        0xFF2196F3L,
+        // green
+        0xFF4CAF50L,
+        // yellow
+        0xFFFFEB3BL,
+        // purple
+        0xFF9C27B0L,
     )
 
 @Composable

--- a/app/src/test/java/com/esde/companion/data/log/EsdeLogFileRepositoryTest.kt
+++ b/app/src/test/java/com/esde/companion/data/log/EsdeLogFileRepositoryTest.kt
@@ -120,7 +120,8 @@ class EsdeLogFileRepositoryTest {
         runTest {
             val logFile = tempFolder.newFile("es_log.txt")
             logFile.writeText(
-                "Jul 28 15:16:07 Debug:  Scripting::fireEvent(): system-select \"psx\" \"Sony PlayStation\" \"/storage/E2AB-E84A/ROMs/psx\" \"\"\n",
+                "Jul 28 15:16:07 Debug:  Scripting::fireEvent(): system-select \"psx\" \"Sony PlayStation\" " +
+                    "\"/storage/E2AB-E84A/ROMs/psx\" \"\"\n",
             )
 
             // Simulates a reboot: the file's real mtime is "now" (test-run time), but boot
@@ -139,7 +140,8 @@ class EsdeLogFileRepositoryTest {
         runTest {
             val logFile = tempFolder.newFile("es_log.txt")
             logFile.writeText(
-                "Jul 28 15:16:07 Debug:  Scripting::fireEvent(): system-select \"psx\" \"Sony PlayStation\" \"/storage/E2AB-E84A/ROMs/psx\" \"\"\n",
+                "Jul 28 15:16:07 Debug:  Scripting::fireEvent(): system-select \"psx\" \"Sony PlayStation\" " +
+                    "\"/storage/E2AB-E84A/ROMs/psx\" \"\"\n",
             )
 
             // Boot reported as happening well before the file's real (test-run time) mtime -

--- a/config/ktlint/baseline.xml
+++ b/config/ktlint/baseline.xml
@@ -1,33 +1,3 @@
 <?xml version="1.0" encoding="utf-8"?>
 <baseline version="1.0">
-    <file name="src/main/java/com/esde/companion/domain/model/WidgetContentResolver.kt">
-        <error line="25" column="1" source="standard:max-line-length" />
-        <error line="33" column="1" source="standard:max-line-length" />
-    </file>
-    <file name="src/main/java/com/esde/companion/ui/main/CrossfadeAsyncImage.kt">
-        <error line="60" column="1" source="standard:no-consecutive-comments" />
-    </file>
-    <file name="src/main/java/com/esde/companion/ui/settings/SettingsContent.kt">
-        <error line="689" column="1" source="standard:max-line-length" />
-    </file>
-    <file name="src/main/java/com/esde/companion/ui/widgets/WidgetCanvas.kt">
-        <error line="215" column="1" source="standard:max-line-length" />
-    </file>
-    <file name="src/main/java/com/esde/companion/ui/widgets/WidgetsViewModel.kt">
-        <error line="206" column="78" source="standard:discouraged-comment-location" />
-    </file>
-    <file name="src/main/java/com/esde/companion/ui/widgets/edit/EditWidgetsOverlay.kt">
-        <error line="1563" column="22" source="standard:discouraged-comment-location" />
-        <error line="1564" column="22" source="standard:discouraged-comment-location" />
-        <error line="1565" column="22" source="standard:discouraged-comment-location" />
-        <error line="1566" column="22" source="standard:discouraged-comment-location" />
-        <error line="1567" column="22" source="standard:discouraged-comment-location" />
-        <error line="1568" column="22" source="standard:discouraged-comment-location" />
-        <error line="1569" column="22" source="standard:discouraged-comment-location" />
-        <error line="1570" column="22" source="standard:discouraged-comment-location" />
-    </file>
-    <file name="src/test/java/com/esde/companion/data/log/EsdeLogFileRepositoryTest.kt">
-        <error line="123" column="1" source="standard:max-line-length" />
-        <error line="142" column="1" source="standard:max-line-length" />
-    </file>
 </baseline>


### PR DESCRIPTION
## Summary
- Phase 1: fixes the 4 pre-existing `!!` non-null assertions (CLAUDE.md hard rule) - `MainActivity.kt`'s video overlay gate and `EditWidgetsOverlay.kt`'s widget-menu actions (Move Forwards/Backwards, Remove). All 4 were smart-cast defeated by a closure or `by ... collectAsStateWithLifecycle()` delegate boundary; fixed by binding to a local val before the closure instead.
- Phase 2: fixes all 16 entries in `config/ktlint/baseline.xml` (`discouraged-comment-location`, `max-line-length`, `no-consecutive-comments`) and empties the baseline. One entry (`SettingsContent.kt`) was stale - that file no longer exists after an earlier split into per-category settings files - so it's just dropped.
- Also fixes one new `ArgumentListWrapping`/`MaxLineLength` issue introduced by the Phase 1 restructuring in `MainActivity.kt` (wrapped a call's arguments).

## Test plan
- [x] `ktlintCheck detekt testDebugUnitTest` pass, ktlint baseline is now empty
- [x] Smoke-test widget-edit long-press menu (Move Forwards/Backwards/Remove)
- [x] Smoke-test video-overlay transition path