### PR TITLE
Technical debt paydown: Phase 4 (repo-wide formatting sweep)

### DIFF
--- a/app/src/main/java/com/esde/companion/data/context/FileLastKnownContextRepository.kt
+++ b/app/src/main/java/com/esde/companion/data/context/FileLastKnownContextRepository.kt
@@ -19,7 +19,10 @@ internal val Context.lastKnownContextDataStore by preferencesDataStore(name = "l
 class FileLastKnownContextRepository(
     private val context: Context,
 ) : LastKnownContextRepository {
-    override fun observeLastSystemShortName(): Flow<String?> = context.lastKnownContextDataStore.data.map { it[SYSTEM_SHORT_NAME_KEY] }
+    override fun observeLastSystemShortName(): Flow<String?> =
+        context.lastKnownContextDataStore.data.map {
+            it[SYSTEM_SHORT_NAME_KEY]
+        }
 
     override suspend fun setLastSystemShortName(systemShortName: String) {
         context.lastKnownContextDataStore.edit { it[SYSTEM_SHORT_NAME_KEY] = systemShortName }

--- a/app/src/main/java/com/esde/companion/data/media/FileGameMediaRepository.kt
+++ b/app/src/main/java/com/esde/companion/data/media/FileGameMediaRepository.kt
@@ -30,7 +30,9 @@ class FileGameMediaRepository(
 
             val filesByType =
                 mediaTypes
-                    .mapNotNull { type -> findExistingFile(type, systemShortName, baseRelativePath)?.let { type to it } }
+                    .mapNotNull { type ->
+                        findExistingFile(type, systemShortName, baseRelativePath)?.let { type to it }
+                    }
                     .toMap()
 
             GameMedia(baseRelativePath = baseRelativePath, filesByType = filesByType)

--- a/app/src/main/java/com/esde/companion/data/settings/FileAppDrawerSettingsRepository.kt
+++ b/app/src/main/java/com/esde/companion/data/settings/FileAppDrawerSettingsRepository.kt
@@ -21,7 +21,10 @@ class FileAppDrawerSettingsRepository(
         context.appDrawerSettingsDataStore.edit { it[HIDDEN_APPS_KEY] = packageNames }
     }
 
-    override fun observeHiddenApps(): Flow<Set<String>> = context.appDrawerSettingsDataStore.data.map { it[HIDDEN_APPS_KEY] ?: emptySet() }
+    override fun observeHiddenApps(): Flow<Set<String>> =
+        context.appDrawerSettingsDataStore.data.map {
+            it[HIDDEN_APPS_KEY] ?: emptySet()
+        }
 
     override suspend fun setGridColumns(columns: Int) {
         context.appDrawerSettingsDataStore.edit { it[GRID_COLUMNS_KEY] = columns.coerceIn(3, 6) }

--- a/app/src/main/java/com/esde/companion/data/settings/FileDockSettingsRepository.kt
+++ b/app/src/main/java/com/esde/companion/data/settings/FileDockSettingsRepository.kt
@@ -25,13 +25,19 @@ class FileDockSettingsRepository(
         context.dockSettingsDataStore.edit { it[DOCK_ENABLED_KEY] = enabled }
     }
 
-    override fun observeDockEnabled(): Flow<Boolean> = context.dockSettingsDataStore.data.map { it[DOCK_ENABLED_KEY] ?: false }
+    override fun observeDockEnabled(): Flow<Boolean> =
+        context.dockSettingsDataStore.data.map {
+            it[DOCK_ENABLED_KEY] ?: false
+        }
 
     override suspend fun setDockMaxApps(maxApps: Int) {
         context.dockSettingsDataStore.edit { it[DOCK_MAX_APPS_KEY] = maxApps.coerceIn(2, 5) }
     }
 
-    override fun observeDockMaxApps(): Flow<Int> = context.dockSettingsDataStore.data.map { it[DOCK_MAX_APPS_KEY] ?: DEFAULT_DOCK_MAX_APPS }
+    override fun observeDockMaxApps(): Flow<Int> =
+        context.dockSettingsDataStore.data.map {
+            it[DOCK_MAX_APPS_KEY] ?: DEFAULT_DOCK_MAX_APPS
+        }
 
     override suspend fun setDockSize(size: DockSize) {
         context.dockSettingsDataStore.edit { it[DOCK_SIZE_KEY] = size.name }

--- a/app/src/main/java/com/esde/companion/data/settings/FileEsdeInstallationRepository.kt
+++ b/app/src/main/java/com/esde/companion/data/settings/FileEsdeInstallationRepository.kt
@@ -101,7 +101,8 @@ class FileEsdeInstallationRepository(
         readSettingsXml(esdeRootPath)?.let { xml ->
             EsdeEventScriptSettings(
                 customEventScripts = EsdeSettingsParser.findBoolValue(xml, "CustomEventScripts") ?: false,
-                customEventScriptsBrowsing = EsdeSettingsParser.findBoolValue(xml, "CustomEventScriptsBrowsing") ?: false,
+                customEventScriptsBrowsing =
+                    EsdeSettingsParser.findBoolValue(xml, "CustomEventScriptsBrowsing") ?: false,
                 debugMode = EsdeSettingsParser.findBoolValue(xml, "DebugMode") ?: false,
                 debugSkipInputLogging = EsdeSettingsParser.findBoolValue(xml, "DebugSkipInputLogging") ?: false,
             )

--- a/app/src/main/java/com/esde/companion/data/settings/FileOnboardingRepository.kt
+++ b/app/src/main/java/com/esde/companion/data/settings/FileOnboardingRepository.kt
@@ -67,9 +67,14 @@ class FileOnboardingRepository(
         context.onboardingDataStore.edit { it[MEDIA_FOLDER_PATH_KEY] = path }
     }
 
-    override fun observeLogFolderPath(): Flow<String?> = context.onboardingDataStore.data.map { it[LOG_FOLDER_PATH_KEY] }
+    override fun observeLogFolderPath(): Flow<String?> {
+        return context.onboardingDataStore.data.map { it[LOG_FOLDER_PATH_KEY] }
+    }
 
-    override fun observeMediaFolderPath(): Flow<String?> = context.onboardingDataStore.data.map { it[MEDIA_FOLDER_PATH_KEY] }
+    override fun observeMediaFolderPath(): Flow<String?> =
+        context.onboardingDataStore.data.map {
+            it[MEDIA_FOLDER_PATH_KEY]
+        }
 
     override suspend fun saveCustomSystemImagesFolderPath(path: String) {
         context.onboardingDataStore.edit { it[CUSTOM_SYSTEM_IMAGES_FOLDER_PATH_KEY] = path }
@@ -86,7 +91,10 @@ class FileOnboardingRepository(
         context.onboardingDataStore.edit { it[CUSTOM_LOGOS_FOLDER_PATH_KEY] = path }
     }
 
-    override fun observeCustomLogosFolderPath(): Flow<String?> = context.onboardingDataStore.data.map { it[CUSTOM_LOGOS_FOLDER_PATH_KEY] }
+    override fun observeCustomLogosFolderPath(): Flow<String?> =
+        context.onboardingDataStore.data.map {
+            it[CUSTOM_LOGOS_FOLDER_PATH_KEY]
+        }
 
     override suspend fun clearCustomLogosFolderPath() {
         context.onboardingDataStore.edit { it.remove(CUSTOM_LOGOS_FOLDER_PATH_KEY) }
@@ -96,7 +104,10 @@ class FileOnboardingRepository(
         context.onboardingDataStore.edit { it[ONBOARDING_COMPLETE_KEY] = true }
     }
 
-    override fun observeOnboardingComplete(): Flow<Boolean> = context.onboardingDataStore.data.map { it[ONBOARDING_COMPLETE_KEY] ?: false }
+    override fun observeOnboardingComplete(): Flow<Boolean> =
+        context.onboardingDataStore.data.map {
+            it[ONBOARDING_COMPLETE_KEY] ?: false
+        }
 
     override suspend fun setThemePreference(preference: ThemePreference) {
         context.onboardingDataStore.edit { it[THEME_PREFERENCE_KEY] = preference.name }
@@ -168,13 +179,19 @@ class FileOnboardingRepository(
         context.onboardingDataStore.edit { it[VIDEO_AUDIO_ENABLED_KEY] = enabled }
     }
 
-    override fun observeVideoAudioEnabled(): Flow<Boolean> = context.onboardingDataStore.data.map { it[VIDEO_AUDIO_ENABLED_KEY] ?: true }
+    override fun observeVideoAudioEnabled(): Flow<Boolean> =
+        context.onboardingDataStore.data.map {
+            it[VIDEO_AUDIO_ENABLED_KEY] ?: true
+        }
 
     override suspend fun setMusicEnabled(enabled: Boolean) {
         context.onboardingDataStore.edit { it[MUSIC_ENABLED_KEY] = enabled }
     }
 
-    override fun observeMusicEnabled(): Flow<Boolean> = context.onboardingDataStore.data.map { it[MUSIC_ENABLED_KEY] ?: false }
+    override fun observeMusicEnabled(): Flow<Boolean> =
+        context.onboardingDataStore.data.map {
+            it[MUSIC_ENABLED_KEY] ?: false
+        }
 
     override suspend fun setMusicPlayWhileBrowsingSystems(enabled: Boolean) {
         context.onboardingDataStore.edit { it[MUSIC_PLAY_WHILE_BROWSING_SYSTEMS_KEY] = enabled }
@@ -221,7 +238,10 @@ class FileOnboardingRepository(
         context.onboardingDataStore.edit { it[CUSTOM_MUSIC_FOLDER_PATH_KEY] = path }
     }
 
-    override fun observeCustomMusicFolderPath(): Flow<String?> = context.onboardingDataStore.data.map { it[CUSTOM_MUSIC_FOLDER_PATH_KEY] }
+    override fun observeCustomMusicFolderPath(): Flow<String?> =
+        context.onboardingDataStore.data.map {
+            it[CUSTOM_MUSIC_FOLDER_PATH_KEY]
+        }
 
     override suspend fun clearCustomMusicFolderPath() {
         context.onboardingDataStore.edit { it.remove(CUSTOM_MUSIC_FOLDER_PATH_KEY) }

--- a/app/src/main/java/com/esde/companion/data/settings/WidgetLayoutMapping.kt
+++ b/app/src/main/java/com/esde/companion/data/settings/WidgetLayoutMapping.kt
@@ -45,7 +45,13 @@ private fun String?.toFallbackMediaType(primaryMediaType: MediaType): MediaType?
 private fun WidgetType.toDto(): WidgetTypeDto =
     when (this) {
         is WidgetType.SystemLogo ->
-            WidgetTypeDto.SystemLogo(scaleMode.toDto(), effects.blurAmount, effects.darkenAmount, logoTransitionMode.toDto(), glintEnabled)
+            WidgetTypeDto.SystemLogo(
+                scaleMode.toDto(),
+                effects.blurAmount,
+                effects.darkenAmount,
+                logoTransitionMode.toDto(),
+                glintEnabled,
+            )
         is WidgetType.SystemImage ->
             WidgetTypeDto.SystemImage(
                 scaleMode.toDto(),
@@ -88,7 +94,13 @@ private fun WidgetType.toDto(): WidgetTypeDto =
                 imageTransitionMode.toDto(),
             )
         is WidgetType.ColorBackground -> WidgetTypeDto.ColorBackground(colorArgb, alpha)
-        is WidgetType.GameDescription -> WidgetTypeDto.GameDescription(fontSizeSp, textColorArgb, backgroundColorArgb, backgroundAlpha)
+        is WidgetType.GameDescription ->
+            WidgetTypeDto.GameDescription(
+                fontSizeSp,
+                textColorArgb,
+                backgroundColorArgb,
+                backgroundAlpha,
+            )
         is WidgetType.Rating ->
             WidgetTypeDto.Rating(
                 noRatingBehavior.toDto(),
@@ -164,9 +176,27 @@ private fun WidgetTypeDto.Rating.toDomainRating(): WidgetType.Rating =
         backgroundAlpha,
     )
 
-private fun PlacedWidget.toDto() = PlacedWidgetDto(id, widgetType.toDto(), gridColumn, gridRow, columnSpan, rowSpan, zIndex)
+private fun PlacedWidget.toDto() =
+    PlacedWidgetDto(
+        id,
+        widgetType.toDto(),
+        gridColumn,
+        gridRow,
+        columnSpan,
+        rowSpan,
+        zIndex,
+    )
 
-private fun PlacedWidgetDto.toDomain() = PlacedWidget(id, widgetType.toDomain(), gridColumn, gridRow, columnSpan, rowSpan, zIndex)
+private fun PlacedWidgetDto.toDomain() =
+    PlacedWidget(
+        id,
+        widgetType.toDomain(),
+        gridColumn,
+        gridRow,
+        columnSpan,
+        rowSpan,
+        zIndex,
+    )
 
 internal fun List<PlacedWidget>.toDtoList() = map { it.toDto() }
 

--- a/app/src/main/java/com/esde/companion/domain/parser/EsdeSettingsParser.kt
+++ b/app/src/main/java/com/esde/companion/domain/parser/EsdeSettingsParser.kt
@@ -24,7 +24,13 @@ object EsdeSettingsParser {
         settingName: String,
     ): Boolean? = boolRegexFor(settingName).find(xmlContent)?.groupValues?.get(1)?.toBooleanStrictOrNull()
 
-    private fun stringRegexFor(settingName: String) = Regex("""<string\s+name="${Regex.escape(settingName)}"\s+value="([^"]*)"\s*/>""")
+    private fun stringRegexFor(settingName: String) =
+        Regex(
+            """<string\s+name="${Regex.escape(settingName)}"\s+value="([^"]*)"\s*/>""",
+        )
 
-    private fun boolRegexFor(settingName: String) = Regex("""<bool\s+name="${Regex.escape(settingName)}"\s+value="([^"]*)"\s*/>""")
+    private fun boolRegexFor(settingName: String) =
+        Regex(
+            """<bool\s+name="${Regex.escape(settingName)}"\s+value="([^"]*)"\s*/>""",
+        )
 }

--- a/app/src/main/java/com/esde/companion/domain/parser/NavigationDirectionParser.kt
+++ b/app/src/main/java/com/esde/companion/domain/parser/NavigationDirectionParser.kt
@@ -21,7 +21,9 @@ object NavigationDirectionParser {
      * or truncated (e.g. cut off mid-line at a tail-window boundary) - the tracker treats
      * that as unparseable noise, not a definitive "no direction" signal, and leaves
      * whatever direction was already tracked untouched. */
-    fun isWellFormedInputLine(rawLine: String): Boolean = isLogInputLine(rawLine) && BUTTON_REGEX.containsMatchIn(rawLine)
+    fun isWellFormedInputLine(rawLine: String): Boolean {
+        return isLogInputLine(rawLine) && BUTTON_REGEX.containsMatchIn(rawLine)
+    }
 
     /**
      * Returns the pressed direction for a well-formed directional button *press* line

--- a/app/src/main/java/com/esde/companion/domain/usecase/FindLegacyScriptFilesUseCase.kt
+++ b/app/src/main/java/com/esde/companion/domain/usecase/FindLegacyScriptFilesUseCase.kt
@@ -5,5 +5,7 @@ import com.esde.companion.domain.repository.EsdeInstallationRepository
 class FindLegacyScriptFilesUseCase(
     private val esdeInstallationRepository: EsdeInstallationRepository,
 ) {
-    suspend operator fun invoke(esdeRootPath: String): List<String> = esdeInstallationRepository.findLegacyScriptFiles(esdeRootPath)
+    suspend operator fun invoke(esdeRootPath: String): List<String> {
+        return esdeInstallationRepository.findLegacyScriptFiles(esdeRootPath)
+    }
 }

--- a/app/src/main/java/com/esde/companion/domain/usecase/ReadEsdeMediaDirectoryUseCase.kt
+++ b/app/src/main/java/com/esde/companion/domain/usecase/ReadEsdeMediaDirectoryUseCase.kt
@@ -5,5 +5,8 @@ import com.esde.companion.domain.repository.EsdeInstallationRepository
 class ReadEsdeMediaDirectoryUseCase(
     private val esdeInstallationRepository: EsdeInstallationRepository,
 ) {
-    suspend operator fun invoke(esdeRootPath: String): String? = esdeInstallationRepository.readMediaDirectory(esdeRootPath)
+    suspend operator fun invoke(esdeRootPath: String): String? =
+        esdeInstallationRepository.readMediaDirectory(
+            esdeRootPath,
+        )
 }

--- a/app/src/main/java/com/esde/companion/domain/usecase/SetOtherScreenLaunchAppsUseCase.kt
+++ b/app/src/main/java/com/esde/companion/domain/usecase/SetOtherScreenLaunchAppsUseCase.kt
@@ -5,5 +5,8 @@ import com.esde.companion.domain.repository.AppDrawerSettingsRepository
 class SetOtherScreenLaunchAppsUseCase(
     private val appDrawerSettingsRepository: AppDrawerSettingsRepository,
 ) {
-    suspend operator fun invoke(packageNames: Set<String>) = appDrawerSettingsRepository.setOtherScreenLaunchApps(packageNames)
+    suspend operator fun invoke(packageNames: Set<String>) =
+        appDrawerSettingsRepository.setOtherScreenLaunchApps(
+            packageNames,
+        )
 }

--- a/app/src/main/java/com/esde/companion/ui/MainActivity.kt
+++ b/app/src/main/java/com/esde/companion/ui/MainActivity.kt
@@ -229,15 +229,19 @@ class MainActivity : ComponentActivity() {
                         }
                         composable(Destinations.MAIN) {
                             val viewModel: MainViewModel = viewModel(factory = MainViewModelFactory(appContainer))
-                            val appDrawerViewModel: AppDrawerViewModel = viewModel(factory = AppDrawerViewModelFactory(appContainer))
-                            val dockViewModel: AppDockViewModel = viewModel(factory = AppDockViewModelFactory(appContainer))
+                            val appDrawerViewModel: AppDrawerViewModel =
+                                viewModel(factory = AppDrawerViewModelFactory(appContainer))
+                            val dockViewModel: AppDockViewModel =
+                                viewModel(factory = AppDockViewModelFactory(appContainer))
                             // Constructed unconditionally now, rather than only while
                             // Settings was showing - the long-press popup that hosts this
                             // content is a child of MainScreen, which is always in
                             // composition (unlike the old standalone SettingsScreen
                             // destination it replaced).
-                            val settingsViewModel: SettingsViewModel = viewModel(factory = SettingsViewModelFactory(appContainer))
-                            val manageAppsViewModel: ManageAppsViewModel = viewModel(factory = ManageAppsViewModelFactory(appContainer))
+                            val settingsViewModel: SettingsViewModel =
+                                viewModel(factory = SettingsViewModelFactory(appContainer))
+                            val manageAppsViewModel: ManageAppsViewModel =
+                                viewModel(factory = ManageAppsViewModelFactory(appContainer))
                             val autoFpsTriggerAppsViewModel: AutoFpsTriggerAppsViewModel =
                                 viewModel(factory = AutoFpsTriggerAppsViewModelFactory(appContainer))
                             val taskKillerExcludedAppsViewModel: TaskKillerExcludedAppsViewModel =
@@ -303,9 +307,11 @@ class MainActivity : ComponentActivity() {
                             val gamePlayingDimPercent by viewModel.gamePlayingDimPercent.collectAsStateWithLifecycle()
                             val screensaverDimPercent by viewModel.screensaverDimPercent.collectAsStateWithLifecycle()
 
-                            val widgetsViewModel: WidgetsViewModel = viewModel(factory = WidgetsViewModelFactory(appContainer))
+                            val widgetsViewModel: WidgetsViewModel =
+                                viewModel(factory = WidgetsViewModelFactory(appContainer))
 
-                            val gameManualViewModel: GameManualViewModel = viewModel(factory = GameManualViewModelFactory(appContainer))
+                            val gameManualViewModel: GameManualViewModel =
+                                viewModel(factory = GameManualViewModelFactory(appContainer))
                             val manualPdfPath by gameManualViewModel.pdfPath.collectAsStateWithLifecycle()
 
                             // Manual "exit" dismissal for the GameManual cover - separate
@@ -579,7 +585,8 @@ class MainActivity : ComponentActivity() {
                                     else -> 0
                                 }
 
-                            val isBrowsingGame = (connectionState as? EsdeConnectionState.Connected)?.appState is AppState.BrowsingGame
+                            val isBrowsingGame =
+                                (connectionState as? EsdeConnectionState.Connected)?.appState is AppState.BrowsingGame
                             val showVideoOverlay =
                                 videoPlaybackEnabled &&
                                     isBrowsingGame &&
@@ -772,7 +779,11 @@ class MainActivity : ComponentActivity() {
                                 // Screensaver Behavior). Purely visual - no clickable or
                                 // pointerInput, so touches pass straight through to
                                 // whatever's underneath, unlike the Black cover below.
-                                AnimatedVisibility(visible = isDimmed && mainScreenActive, enter = fadeIn(), exit = fadeOut()) {
+                                AnimatedVisibility(
+                                    visible = isDimmed && mainScreenActive,
+                                    enter = fadeIn(),
+                                    exit = fadeOut(),
+                                ) {
                                     Box(
                                         modifier =
                                             Modifier
@@ -796,7 +807,11 @@ class MainActivity : ComponentActivity() {
                                 // MainScreen's long-press-to-edit, widget taps - receives
                                 // input while blanked. "Blanked" should mean genuinely
                                 // unreachable, not just visually covered.
-                                AnimatedVisibility(visible = isBlanked && mainScreenActive, enter = fadeIn(), exit = fadeOut()) {
+                                AnimatedVisibility(
+                                    visible = isBlanked && mainScreenActive,
+                                    enter = fadeIn(),
+                                    exit = fadeOut(),
+                                ) {
                                     Box(
                                         modifier =
                                             Modifier
@@ -820,7 +835,11 @@ class MainActivity : ComponentActivity() {
                                 // its own branch rather than reusing isBlanked, since it
                                 // renders interactive content (paged/zoomable PDF) rather
                                 // than a plain cover.
-                                AnimatedVisibility(visible = showGameManual && mainScreenActive, enter = fadeIn(), exit = fadeOut()) {
+                                AnimatedVisibility(
+                                    visible = showGameManual && mainScreenActive,
+                                    enter = fadeIn(),
+                                    exit = fadeOut(),
+                                ) {
                                     GameManualScreen(
                                         viewModel = gameManualViewModel,
                                         onExit = {

--- a/app/src/main/java/com/esde/companion/ui/dock/AppDock.kt
+++ b/app/src/main/java/com/esde/companion/ui/dock/AppDock.kt
@@ -76,13 +76,21 @@ private const val DOCK_PREVIEW_ALPHA = 0.65f
 /** Dock background base color: black in dark mode, white in light mode - same
  * theme-detection approach as MusicControlsOverlay's content/background colors. */
 @Composable
-private fun dockBackgroundColor(): Color = if (MaterialTheme.colorScheme.surface.luminance() < 0.5f) Color.Black else Color.White
+private fun dockBackgroundColor(): Color {
+    return if (MaterialTheme.colorScheme.surface.luminance() < 0.5f) Color.Black else Color.White
+}
 
 /** Empty-slot border/icon color: the inverse of [dockBackgroundColor], so the "add app"
  * placeholder stays visible against the dock's background in either theme. */
 @Composable
 private fun dockContentColor(): Color =
-    if (MaterialTheme.colorScheme.surface.luminance() < 0.5f) Color.White.copy(alpha = 0.3f) else Color.Black.copy(alpha = 0.3f)
+    if (MaterialTheme.colorScheme.surface.luminance() < 0.5f) {
+        Color.White.copy(
+            alpha = 0.3f,
+        )
+    } else {
+        Color.Black.copy(alpha = 0.3f)
+    }
 
 /** Same inverse-of-[dockBackgroundColor] logic as [dockContentColor], full opacity - for
  * the App Drawer shortcut's glyph (Icons.Filled.Apps), which - unlike a real app's own
@@ -90,7 +98,9 @@ private fun dockContentColor(): Color =
  * clearly against the dock's forced black/white background rather than whatever the
  * ambient content color happens to be. */
 @Composable
-private fun appDrawerShortcutIconTint(): Color = if (MaterialTheme.colorScheme.surface.luminance() < 0.5f) Color.White else Color.Black
+private fun appDrawerShortcutIconTint(): Color {
+    return if (MaterialTheme.colorScheme.surface.luminance() < 0.5f) Color.White else Color.Black
+}
 
 private fun DockSize.iconDp(): Dp =
     when (this) {
@@ -221,7 +231,11 @@ fun AppDock(
                         },
                         onLaunchOtherScreen = {
                             viewModel.recordLaunchLocation(app.packageName, LaunchLocation.OtherScreen)
-                            AppLauncher.launch(context, app.packageName, displayId = SecondaryDisplayResolver.secondaryDisplayId(context))
+                            AppLauncher.launch(
+                                context,
+                                app.packageName,
+                                displayId = SecondaryDisplayResolver.secondaryDisplayId(context),
+                            )
                         },
                         onAppInfo = { AppLauncher.openAppInfo(context, app.packageName) },
                         onMoveLeft = { viewModel.moveLeft(app.packageName) },

--- a/app/src/main/java/com/esde/companion/ui/dock/AppDockViewModel.kt
+++ b/app/src/main/java/com/esde/companion/ui/dock/AppDockViewModel.kt
@@ -50,11 +50,19 @@ class AppDockViewModel(
 ) : ViewModel() {
     val dockEnabled: StateFlow<Boolean> =
         observeDockEnabled()
-            .stateIn(scope = viewModelScope, started = SharingStarted.WhileSubscribed(stopTimeoutMillis = 5_000), initialValue = false)
+            .stateIn(
+                scope = viewModelScope,
+                started = SharingStarted.WhileSubscribed(stopTimeoutMillis = 5_000),
+                initialValue = false,
+            )
 
     val maxApps: StateFlow<Int> =
         observeDockMaxApps()
-            .stateIn(scope = viewModelScope, started = SharingStarted.WhileSubscribed(stopTimeoutMillis = 5_000), initialValue = 5)
+            .stateIn(
+                scope = viewModelScope,
+                started = SharingStarted.WhileSubscribed(stopTimeoutMillis = 5_000),
+                initialValue = 5,
+            )
 
     val dockSize: StateFlow<DockSize> =
         observeDockSize()
@@ -66,7 +74,11 @@ class AppDockViewModel(
 
     val dockOpacityPercent: StateFlow<Int> =
         observeOverlayOpacity()
-            .stateIn(scope = viewModelScope, started = SharingStarted.WhileSubscribed(stopTimeoutMillis = 5_000), initialValue = 80)
+            .stateIn(
+                scope = viewModelScope,
+                started = SharingStarted.WhileSubscribed(stopTimeoutMillis = 5_000),
+                initialValue = 80,
+            )
 
     /** The pinned apps actually shown, in order, resolved to their current
      * label/packageName and capped to [maxApps] - lowering the max never deletes
@@ -82,13 +94,21 @@ class AppDockViewModel(
             pinned.take(max).mapNotNull { pkg ->
                 if (pkg == APP_DRAWER_SHORTCUT_PACKAGE_NAME) AppDrawerShortcut else byPackageName[pkg]
             }
-        }.stateIn(scope = viewModelScope, started = SharingStarted.WhileSubscribed(stopTimeoutMillis = 5_000), initialValue = emptyList())
+        }.stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.WhileSubscribed(stopTimeoutMillis = 5_000),
+            initialValue = emptyList(),
+        )
 
     /** Packages whose last-used launch location is the other screen - same set the App
      * Drawer reads/writes, see the class kdoc. */
     val otherScreenLaunchApps: StateFlow<Set<String>> =
         observeOtherScreenLaunchApps()
-            .stateIn(scope = viewModelScope, started = SharingStarted.WhileSubscribed(stopTimeoutMillis = 5_000), initialValue = emptySet())
+            .stateIn(
+                scope = viewModelScope,
+                started = SharingStarted.WhileSubscribed(stopTimeoutMillis = 5_000),
+                initialValue = emptySet(),
+            )
 
     /** Installed apps not already pinned - the candidate list for the "add app to
      * dock" picker opened by long-pressing an empty slot. [AppDrawerShortcut] is
@@ -98,7 +118,11 @@ class AppDockViewModel(
         combine(observeInstalledApps(), observeDockApps()) { installed, pinned ->
             val realApps = installed.filterNot { it.packageName in pinned }
             if (APP_DRAWER_SHORTCUT_PACKAGE_NAME in pinned) realApps else listOf(AppDrawerShortcut) + realApps
-        }.stateIn(scope = viewModelScope, started = SharingStarted.WhileSubscribed(stopTimeoutMillis = 5_000), initialValue = emptyList())
+        }.stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.WhileSubscribed(stopTimeoutMillis = 5_000),
+            initialValue = emptyList(),
+        )
 
     fun recordLaunchLocation(
         packageName: String,

--- a/app/src/main/java/com/esde/companion/ui/drawer/AppDrawer.kt
+++ b/app/src/main/java/com/esde/companion/ui/drawer/AppDrawer.kt
@@ -109,12 +109,16 @@ private val FOLDER_MOSAIC_SPACING = 2.dp
 /** Drawer background base color: black in dark mode, white in light mode - matches
  * AppDock's [dockBackgroundColor] so the drawer and dock read as one consistent surface. */
 @Composable
-internal fun drawerBackgroundColor(): Color = if (MaterialTheme.colorScheme.surface.luminance() < 0.5f) Color.Black else Color.White
+internal fun drawerBackgroundColor(): Color {
+    return if (MaterialTheme.colorScheme.surface.luminance() < 0.5f) Color.Black else Color.White
+}
 
 /** App label text color: the inverse of [drawerBackgroundColor], so labels stay readable
  * against the drawer's background in either theme. */
 @Composable
-internal fun drawerContentColor(): Color = if (MaterialTheme.colorScheme.surface.luminance() < 0.5f) Color.White else Color.Black
+internal fun drawerContentColor(): Color {
+    return if (MaterialTheme.colorScheme.surface.luminance() < 0.5f) Color.White else Color.Black
+}
 
 /** Two-step "add to folder" flow state, hoisted here (mirrors how AppDock hoists its own
  * add-app dialog state) rather than inside AppDrawerItem, since it drives a dialog that

--- a/app/src/main/java/com/esde/companion/ui/drawer/AppDrawerViewModel.kt
+++ b/app/src/main/java/com/esde/companion/ui/drawer/AppDrawerViewModel.kt
@@ -181,7 +181,8 @@ class AppDrawerViewModel(
         packageName: String,
     ) {
         viewModelScope.launch {
-            val newFolder = AppFolder(id = UUID.randomUUID().toString(), name = name, memberPackageNames = setOf(packageName))
+            val newFolder =
+                AppFolder(id = UUID.randomUUID().toString(), name = name, memberPackageNames = setOf(packageName))
             setAppFolders(observeAppFolders().first() + newFolder)
         }
     }

--- a/app/src/main/java/com/esde/companion/ui/main/AutoCollectionAssets.kt
+++ b/app/src/main/java/com/esde/companion/ui/main/AutoCollectionAssets.kt
@@ -19,4 +19,6 @@ private val AUTO_COLLECTION_ASSET_NAMES =
         "recent" to "auto-lastplayed",
     )
 
-fun systemLogoAssetName(systemShortName: String): String = AUTO_COLLECTION_ASSET_NAMES[systemShortName] ?: systemShortName
+fun systemLogoAssetName(systemShortName: String): String {
+    return AUTO_COLLECTION_ASSET_NAMES[systemShortName] ?: systemShortName
+}

--- a/app/src/main/java/com/esde/companion/ui/main/LongPressSettingsMenu.kt
+++ b/app/src/main/java/com/esde/companion/ui/main/LongPressSettingsMenu.kt
@@ -279,7 +279,9 @@ fun LongPressSettingsMenu(
                         val slideDistance = { width: Int -> width / 3 }
                         if (enteringDeeper) {
                             (slideInHorizontally(tween(220), slideDistance) + fadeIn(tween(220)))
-                                .togetherWith(slideOutHorizontally(tween(220)) { -slideDistance(it) } + fadeOut(tween(150)))
+                                .togetherWith(
+                                    slideOutHorizontally(tween(220)) { -slideDistance(it) } + fadeOut(tween(150)),
+                                )
                         } else {
                             (slideInHorizontally(tween(220)) { -slideDistance(it) } + fadeIn(tween(220)))
                                 .togetherWith(slideOutHorizontally(tween(220), slideDistance) + fadeOut(tween(150)))
@@ -311,8 +313,10 @@ fun LongPressSettingsMenu(
                                         uiState = uiState,
                                         onLogFolderPicked = settingsViewModel::onLogFolderPicked,
                                         onMediaFolderPicked = settingsViewModel::onMediaFolderPicked,
-                                        onCustomSystemImagesFolderPicked = settingsViewModel::onCustomSystemImagesFolderPicked,
-                                        onCustomSystemImagesFolderCleared = settingsViewModel::onCustomSystemImagesFolderCleared,
+                                        onCustomSystemImagesFolderPicked =
+                                            settingsViewModel::onCustomSystemImagesFolderPicked,
+                                        onCustomSystemImagesFolderCleared =
+                                            settingsViewModel::onCustomSystemImagesFolderCleared,
                                         onCustomLogosFolderPicked = settingsViewModel::onCustomLogosFolderPicked,
                                         onCustomLogosFolderCleared = settingsViewModel::onCustomLogosFolderCleared,
                                         onCustomMusicFolderPicked = settingsViewModel::onCustomMusicFolderPicked,
@@ -330,11 +334,13 @@ fun LongPressSettingsMenu(
                                         gamePlayingBehavior = uiState.gamePlayingBehavior,
                                         onGamePlayingBehaviorChanged = settingsViewModel::onGamePlayingBehaviorChanged,
                                         gamePlayingDimPercent = uiState.gamePlayingDimPercent,
-                                        onGamePlayingDimPercentChanged = settingsViewModel::onGamePlayingDimPercentChanged,
+                                        onGamePlayingDimPercentChanged =
+                                            settingsViewModel::onGamePlayingDimPercentChanged,
                                         screensaverBehavior = uiState.screensaverBehavior,
                                         onScreensaverBehaviorChanged = settingsViewModel::onScreensaverBehaviorChanged,
                                         screensaverDimPercent = uiState.screensaverDimPercent,
-                                        onScreensaverDimPercentChanged = settingsViewModel::onScreensaverDimPercentChanged,
+                                        onScreensaverDimPercentChanged =
+                                            settingsViewModel::onScreensaverDimPercentChanged,
                                         fabAssignments = uiState.fabAssignments,
                                         installedApps = uiState.installedApps,
                                         onFabTypeChanged = settingsViewModel::onFabTypeChanged,
@@ -344,7 +350,8 @@ fun LongPressSettingsMenu(
                                 SettingsCategory.VideoPlayback ->
                                     VideoPlaybackSettingsContent(
                                         videoPlaybackEnabled = uiState.videoPlaybackEnabled,
-                                        onVideoPlaybackEnabledChanged = settingsViewModel::onVideoPlaybackEnabledChanged,
+                                        onVideoPlaybackEnabledChanged =
+                                            settingsViewModel::onVideoPlaybackEnabledChanged,
                                         videoDelaySeconds = uiState.videoDelaySeconds,
                                         onVideoDelaySecondsChanged = settingsViewModel::onVideoDelaySecondsChanged,
                                         videoAudioEnabled = uiState.videoAudioEnabled,
@@ -358,7 +365,9 @@ fun LongPressSettingsMenu(
                                         onSortFoldersOnTopChanged = settingsViewModel::onSortFoldersOnTopChanged,
                                         showSearchBar = uiState.showSearchBar,
                                         onShowSearchBarChanged = settingsViewModel::onShowSearchBarChanged,
-                                        onManageAppsClick = { page = MenuPage.ManageApps(fromCategory = targetPage.category) },
+                                        onManageAppsClick = {
+                                            page = MenuPage.ManageApps(fromCategory = targetPage.category)
+                                        },
                                         dockEnabled = uiState.dockEnabled,
                                         onDockEnabledChanged = settingsViewModel::onDockEnabledChanged,
                                         dockMaxApps = uiState.dockMaxApps,
@@ -371,11 +380,14 @@ fun LongPressSettingsMenu(
                                         musicEnabled = uiState.musicEnabled,
                                         onMusicEnabledChanged = settingsViewModel::onMusicEnabledChanged,
                                         musicPlayWhileBrowsingSystems = uiState.musicPlayWhileBrowsingSystems,
-                                        onMusicPlayWhileBrowsingSystemsChanged = settingsViewModel::onMusicPlayWhileBrowsingSystemsChanged,
+                                        onMusicPlayWhileBrowsingSystemsChanged =
+                                            settingsViewModel::onMusicPlayWhileBrowsingSystemsChanged,
                                         musicPlayWhileBrowsingGames = uiState.musicPlayWhileBrowsingGames,
-                                        onMusicPlayWhileBrowsingGamesChanged = settingsViewModel::onMusicPlayWhileBrowsingGamesChanged,
+                                        onMusicPlayWhileBrowsingGamesChanged =
+                                            settingsViewModel::onMusicPlayWhileBrowsingGamesChanged,
                                         musicPlayDuringScreensaver = uiState.musicPlayDuringScreensaver,
-                                        onMusicPlayDuringScreensaverChanged = settingsViewModel::onMusicPlayDuringScreensaverChanged,
+                                        onMusicPlayDuringScreensaverChanged =
+                                            settingsViewModel::onMusicPlayDuringScreensaverChanged,
                                         musicDuckingMode = uiState.musicDuckingMode,
                                         onMusicDuckingModeChanged = settingsViewModel::onMusicDuckingModeChanged,
                                     )
@@ -385,13 +397,17 @@ fun LongPressSettingsMenu(
                                         isCheckingForUpdate = updateUiState.isCheckingForUpdate,
                                         onCheckForUpdatesClicked = updateViewModel::checkForUpdatesManually,
                                         closeCompanionOnQuitEnabled = uiState.closeCompanionOnQuitEnabled,
-                                        onCloseCompanionOnQuitEnabledChanged = settingsViewModel::onCloseCompanionOnQuitEnabledChanged,
+                                        onCloseCompanionOnQuitEnabledChanged =
+                                            settingsViewModel::onCloseCompanionOnQuitEnabledChanged,
                                         launchEsdeOnStartEnabled = uiState.launchEsdeOnStartEnabled,
                                         onLaunchEsdeOnStartEnabledChanged = onLaunchEsdeOnStartEnabledChanged,
                                         debugLoggingEnabled = uiState.debugLoggingEnabled,
                                         onDebugLoggingEnabledChanged = settingsViewModel::onDebugLoggingEnabledChanged,
                                     )
-                                SettingsCategory.Widgets -> WidgetsSettingsContent(onEditWidgetsClick = onEditWidgetsClick)
+                                SettingsCategory.Widgets ->
+                                    WidgetsSettingsContent(
+                                        onEditWidgetsClick = onEditWidgetsClick,
+                                    )
                                 SettingsCategory.RetroAchievements ->
                                     RetroAchievementsSettingsContent(
                                         credentials = uiState.retroAchievementsCredentials,

--- a/app/src/main/java/com/esde/companion/ui/music/MusicControlsOverlay.kt
+++ b/app/src/main/java/com/esde/companion/ui/music/MusicControlsOverlay.kt
@@ -115,7 +115,9 @@ fun MusicControlsOverlay(
                 }
             val titleWidth =
                 with(density) {
-                    (0 until titleLayout.lineCount).maxOf { titleLayout.getLineRight(it) - titleLayout.getLineLeft(it) }.toDp()
+                    (0 until titleLayout.lineCount)
+                        .maxOf { titleLayout.getLineRight(it) - titleLayout.getLineLeft(it) }
+                        .toDp()
                 }
 
             Row(

--- a/app/src/main/java/com/esde/companion/ui/onboarding/OnboardingScreen.kt
+++ b/app/src/main/java/com/esde/companion/ui/onboarding/OnboardingScreen.kt
@@ -133,10 +133,14 @@ fun OnboardingScreen(
                             val slideDistance = { width: Int -> width / 3 }
                             if (movingForward) {
                                 (slideInHorizontally(tween(220)) { slideDistance(it) } + fadeIn(tween(220)))
-                                    .togetherWith(slideOutHorizontally(tween(220)) { -slideDistance(it) } + fadeOut(tween(150)))
+                                    .togetherWith(
+                                        slideOutHorizontally(tween(220)) { -slideDistance(it) } + fadeOut(tween(150)),
+                                    )
                             } else {
                                 (slideInHorizontally(tween(220)) { -slideDistance(it) } + fadeIn(tween(220)))
-                                    .togetherWith(slideOutHorizontally(tween(220)) { slideDistance(it) } + fadeOut(tween(150)))
+                                    .togetherWith(
+                                        slideOutHorizontally(tween(220)) { slideDistance(it) } + fadeOut(tween(150)),
+                                    )
                             }
                         },
                         label = "onboardingStepContent",
@@ -272,7 +276,10 @@ private fun EsdeFolderStep(
                     "This folder exists, but settings/es_settings.xml wasn't found inside it - " +
                         "it appears to be the incorrect folder. Choose the correct one to continue.",
                 )
-            validation is LogFolderValidation.FolderNotFound -> Text("This folder doesn't exist. Choose the correct folder.")
+            validation is LogFolderValidation.FolderNotFound ->
+                Text(
+                    "This folder doesn't exist. Choose the correct folder.",
+                )
         }
 
         if (isCheckingInstallation) {
@@ -315,7 +322,10 @@ private fun MediaFolderStep(
                 Text(
                     "ES-DE's settings point at this path, but it doesn't exist - choose the correct folder.",
                 )
-            validation is MediaFolderValidation.FolderNotFound -> Text("This folder doesn't exist. Choose the correct folder.")
+            validation is MediaFolderValidation.FolderNotFound ->
+                Text(
+                    "This folder doesn't exist. Choose the correct folder.",
+                )
         }
 
         OutlinedButton(onClick = { launcher.launch(null) }) {

--- a/app/src/main/java/com/esde/companion/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/esde/companion/ui/settings/SettingsViewModel.kt
@@ -500,7 +500,8 @@ class SettingsViewModel(
     private suspend fun validateCustomMusicFolder(path: String) {
         _uiState.value = _uiState.value.copy(isValidatingCustomMusicFolder = true)
         val result = validateMediaFolderUseCase(path)
-        _uiState.value = _uiState.value.copy(isValidatingCustomMusicFolder = false, customMusicFolderValidation = result)
+        _uiState.value =
+            _uiState.value.copy(isValidatingCustomMusicFolder = false, customMusicFolderValidation = result)
     }
 
     fun onThemePreferenceChanged(preference: ThemePreference) {
@@ -598,7 +599,8 @@ class SettingsViewModel(
     private suspend fun validateCustomLogosFolder(path: String) {
         _uiState.value = _uiState.value.copy(isValidatingCustomLogosFolder = true)
         val result = validateMediaFolderUseCase(path)
-        _uiState.value = _uiState.value.copy(isValidatingCustomLogosFolder = false, customLogosFolderValidation = result)
+        _uiState.value =
+            _uiState.value.copy(isValidatingCustomLogosFolder = false, customLogosFolderValidation = result)
     }
 
     fun onRetroAchievementsUsernameInputChanged(username: String) {

--- a/app/src/main/java/com/esde/companion/ui/settings/SetupSettingsContent.kt
+++ b/app/src/main/java/com/esde/companion/ui/settings/SetupSettingsContent.kt
@@ -396,7 +396,11 @@ private fun LogFolderValidation?.toStatusText(): String =
         null -> ""
         is LogFolderValidation.FolderNotFound -> "Folder not found"
         is LogFolderValidation.FolderFound ->
-            if (settingsFileFound) "settings/es_settings.xml found" else "Folder found, but appears to be the incorrect folder"
+            if (settingsFileFound) {
+                "settings/es_settings.xml found"
+            } else {
+                "Folder found, but appears to be the incorrect folder"
+            }
     }
 
 private fun MediaFolderValidation?.toStatusText(): String =

--- a/app/src/main/java/com/esde/companion/ui/settings/UISettingsContent.kt
+++ b/app/src/main/java/com/esde/companion/ui/settings/UISettingsContent.kt
@@ -116,7 +116,13 @@ internal fun UISettingsContent(
         ScreenBehaviorPicker(
             title = "Game Playing Screen Behavior",
             icon = Icons.Filled.SportsEsports,
-            options = listOf(ScreenBehavior.Nothing, ScreenBehavior.Dim, ScreenBehavior.Black, ScreenBehavior.GameManual),
+            options =
+                listOf(
+                    ScreenBehavior.Nothing,
+                    ScreenBehavior.Dim,
+                    ScreenBehavior.Black,
+                    ScreenBehavior.GameManual,
+                ),
             selected = gamePlayingBehavior,
             onSelected = onGamePlayingBehaviorChanged,
             dimAmount = DimAmountControl(gamePlayingDimPercent, onGamePlayingDimPercentChanged),

--- a/app/src/main/java/com/esde/companion/ui/widgets/WidgetCanvas.kt
+++ b/app/src/main/java/com/esde/companion/ui/widgets/WidgetCanvas.kt
@@ -215,7 +215,8 @@ internal fun WidgetContentView(
         // unreachable: SystemLogoAsset only occurs for SystemLogo widgetType, which isLogoStyle handles above
         is WidgetContent.SystemLogoAsset -> Unit
 
-        is WidgetContent.NameFallback -> Unit // unreachable: only ever produced for isLogoStyle widget types, handled above
+        // unreachable: only ever produced for isLogoStyle widget types, handled above
+        is WidgetContent.NameFallback -> Unit
 
         is WidgetContent.Text ->
             Box(

--- a/app/src/main/java/com/esde/companion/ui/widgets/WidgetsViewModel.kt
+++ b/app/src/main/java/com/esde/companion/ui/widgets/WidgetsViewModel.kt
@@ -123,7 +123,11 @@ class WidgetsViewModel(
                     flowOf(WidgetCanvasState.Disconnected)
                 } else {
                     observeWidgetCanvas(identity.stateGroup, grid).map { widgets ->
-                        WidgetCanvasState.Showing(widgets, resolveContent(widgets, identity), identity.navigationDirection)
+                        WidgetCanvasState.Showing(
+                            widgets,
+                            resolveContent(widgets, identity),
+                            identity.navigationDirection,
+                        )
                     }
                 }
             }
@@ -173,14 +177,25 @@ class WidgetsViewModel(
             ).distinct()
         val systemMediaByType: Map<MediaType, String?> =
             systemShortName?.let { shortName ->
-                neededSystemMediaTypes.associateWith { mediaType -> resolveRandomSystemMediaCached(shortName, mediaType) }
+                neededSystemMediaTypes.associateWith { mediaType ->
+                    resolveRandomSystemMediaCached(shortName, mediaType)
+                }
             } ?: emptyMap()
 
         val systemLogoAssetPath = systemShortName?.let { resolveBundledSystemLogo(systemLogoAssetName(it)) }
 
         val needsCustomLogo = widgets.any { it.widgetType is WidgetType.SystemLogo }
         val needsCustomImage = widgets.any { it.widgetType is WidgetType.SystemImage }
-        val customSystemLogoPath = if (needsCustomLogo) systemShortName?.let { resolveCustomSystemLogo(systemLogoAssetName(it)) } else null
+        val customSystemLogoPath =
+            if (needsCustomLogo) {
+                systemShortName?.let {
+                    resolveCustomSystemLogo(
+                        systemLogoAssetName(it),
+                    )
+                }
+            } else {
+                null
+            }
         val customSystemImagePath =
             if (needsCustomImage) {
                 systemShortName?.let {

--- a/app/src/main/java/com/esde/companion/ui/widgets/edit/EditWidgetsOverlay.kt
+++ b/app/src/main/java/com/esde/companion/ui/widgets/edit/EditWidgetsOverlay.kt
@@ -362,11 +362,21 @@ fun EditWidgetsOverlay(
 
                     for (column in 1 until grid.columns) {
                         val x = cellWidthPx * column
-                        drawLine(color = gridLineColor, start = Offset(x, 0f), end = Offset(x, size.height), strokeWidth = 2f)
+                        drawLine(
+                            color = gridLineColor,
+                            start = Offset(x, 0f),
+                            end = Offset(x, size.height),
+                            strokeWidth = 2f,
+                        )
                     }
                     for (row in 1 until grid.rows) {
                         val y = cellHeightPx * row
-                        drawLine(color = gridLineColor, start = Offset(0f, y), end = Offset(size.width, y), strokeWidth = 2f)
+                        drawLine(
+                            color = gridLineColor,
+                            start = Offset(0f, y),
+                            end = Offset(size.width, y),
+                            strokeWidth = 2f,
+                        )
                     }
                 }
             }
@@ -575,7 +585,10 @@ private fun PlaceholderWidgetBox(
                 .padding(WIDGET_BORDER_INSET)
                 .then(
                     if (isPlaceholder) {
-                        Modifier.background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.6f), RoundedCornerShape(8.dp))
+                        Modifier.background(
+                            MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.6f),
+                            RoundedCornerShape(8.dp),
+                        )
                     } else {
                         Modifier
                     },

--- a/app/src/main/java/com/esde/companion/ui/widgets/edit/EditWidgetsViewModel.kt
+++ b/app/src/main/java/com/esde/companion/ui/widgets/edit/EditWidgetsViewModel.kt
@@ -381,7 +381,9 @@ class EditWidgetsViewModel(
         val systemMediaByType: Map<MediaType, String?> =
             lastSystemShortName?.let { shortName ->
                 neededSystemMediaTypes.associateWith { mediaType ->
-                    randomSystemMediaCache.getOrPut(shortName to mediaType) { resolveRandomSystemMedia(shortName, mediaType) }
+                    randomSystemMediaCache.getOrPut(shortName to mediaType) {
+                        resolveRandomSystemMedia(shortName, mediaType)
+                    }
                 }
             } ?: emptyMap()
 

--- a/app/src/main/java/com/esde/companion/ui/widgets/edit/WidgetColorConfig.kt
+++ b/app/src/main/java/com/esde/companion/ui/widgets/edit/WidgetColorConfig.kt
@@ -88,7 +88,10 @@ internal fun ColorBackgroundConfig(
             HexColorInput(current = current.colorArgb) { onChange(current.copy(colorArgb = it)) }
         }
         Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
-            Text(text = "Transparency: ${(current.alpha * 100).roundToInt()}%", style = MaterialTheme.typography.titleSmall)
+            Text(
+                text = "Transparency: ${(current.alpha * 100).roundToInt()}%",
+                style = MaterialTheme.typography.titleSmall,
+            )
             Slider(
                 value = current.alpha,
                 onValueChange = { onChange(current.copy(alpha = it)) },

--- a/app/src/main/java/com/esde/companion/ui/widgets/edit/WidgetImageConfigControls.kt
+++ b/app/src/main/java/com/esde/companion/ui/widgets/edit/WidgetImageConfigControls.kt
@@ -118,7 +118,10 @@ internal fun ImageEffectsConfig(
 ) {
     Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
         Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
-            Text(text = "Blur: ${(current.blurAmount * 100).roundToInt()}%", style = MaterialTheme.typography.titleSmall)
+            Text(
+                text = "Blur: ${(current.blurAmount * 100).roundToInt()}%",
+                style = MaterialTheme.typography.titleSmall,
+            )
             Slider(
                 value = current.blurAmount,
                 onValueChange = { onChange(current.copy(blurAmount = it)) },
@@ -126,7 +129,10 @@ internal fun ImageEffectsConfig(
             )
         }
         Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
-            Text(text = "Darken: ${(current.darkenAmount * 100).roundToInt()}%", style = MaterialTheme.typography.titleSmall)
+            Text(
+                text = "Darken: ${(current.darkenAmount * 100).roundToInt()}%",
+                style = MaterialTheme.typography.titleSmall,
+            )
             Slider(
                 value = current.darkenAmount,
                 onValueChange = { onChange(current.copy(darkenAmount = it)) },

--- a/app/src/main/java/com/esde/companion/ui/widgets/edit/WidgetTypeDialogs.kt
+++ b/app/src/main/java/com/esde/companion/ui/widgets/edit/WidgetTypeDialogs.kt
@@ -139,7 +139,9 @@ internal fun ConfigureWidgetDialog(
                 when (widgetType) {
                     is WidgetType.SystemLogo -> {
                         ScaleModeConfig(current = widgetType.scaleMode) { onChange(widgetType.copy(scaleMode = it)) }
-                        LogoTransitionPicker(current = widgetType.logoTransitionMode) { onChange(widgetType.copy(logoTransitionMode = it)) }
+                        LogoTransitionPicker(
+                            current = widgetType.logoTransitionMode,
+                        ) { onChange(widgetType.copy(logoTransitionMode = it)) }
                         GlintConfig(enabled = widgetType.glintEnabled) { onChange(widgetType.copy(glintEnabled = it)) }
                         ImageEffectsConfig(current = widgetType.effects) { onChange(widgetType.copy(effects = it)) }
                     }
@@ -152,7 +154,9 @@ internal fun ConfigureWidgetDialog(
                             ) { onChange(widgetType.copy(imageTransitionMode = it)) }
                         }
                         if (widgetType.supportsPanZoom) {
-                            PanZoomConfig(enabled = widgetType.panZoomEnabled) { onChange(widgetType.copy(panZoomEnabled = it)) }
+                            PanZoomConfig(
+                                enabled = widgetType.panZoomEnabled,
+                            ) { onChange(widgetType.copy(panZoomEnabled = it)) }
                         }
                         ImageEffectsConfig(current = widgetType.effects) { onChange(widgetType.copy(effects = it)) }
                     }
@@ -163,14 +167,18 @@ internal fun ConfigureWidgetDialog(
                             LogoTransitionPicker(
                                 current = widgetType.logoTransitionMode,
                             ) { onChange(widgetType.copy(logoTransitionMode = it)) }
-                            GlintConfig(enabled = widgetType.glintEnabled) { onChange(widgetType.copy(glintEnabled = it)) }
+                            GlintConfig(
+                                enabled = widgetType.glintEnabled,
+                            ) { onChange(widgetType.copy(glintEnabled = it)) }
                         } else if (widgetType.supportsImageTransition && widgetType.allowsFadeTransition) {
                             ImageTransitionPicker(
                                 current = widgetType.imageTransitionMode,
                             ) { onChange(widgetType.copy(imageTransitionMode = it)) }
                         }
                         if (widgetType.supportsPanZoom) {
-                            PanZoomConfig(enabled = widgetType.panZoomEnabled) { onChange(widgetType.copy(panZoomEnabled = it)) }
+                            PanZoomConfig(
+                                enabled = widgetType.panZoomEnabled,
+                            ) { onChange(widgetType.copy(panZoomEnabled = it)) }
                         }
                         if (widgetType.supportsFallbackArtwork) {
                             FallbackArtworkConfig(
@@ -187,14 +195,18 @@ internal fun ConfigureWidgetDialog(
                             LogoTransitionPicker(
                                 current = widgetType.logoTransitionMode,
                             ) { onChange(widgetType.copy(logoTransitionMode = it)) }
-                            GlintConfig(enabled = widgetType.glintEnabled) { onChange(widgetType.copy(glintEnabled = it)) }
+                            GlintConfig(
+                                enabled = widgetType.glintEnabled,
+                            ) { onChange(widgetType.copy(glintEnabled = it)) }
                         } else if (widgetType.supportsImageTransition && widgetType.allowsFadeTransition) {
                             ImageTransitionPicker(
                                 current = widgetType.imageTransitionMode,
                             ) { onChange(widgetType.copy(imageTransitionMode = it)) }
                         }
                         if (widgetType.supportsPanZoom) {
-                            PanZoomConfig(enabled = widgetType.panZoomEnabled) { onChange(widgetType.copy(panZoomEnabled = it)) }
+                            PanZoomConfig(
+                                enabled = widgetType.panZoomEnabled,
+                            ) { onChange(widgetType.copy(panZoomEnabled = it)) }
                         }
                         if (widgetType.supportsFallbackArtwork) {
                             FallbackArtworkConfig(
@@ -214,7 +226,9 @@ internal fun ConfigureWidgetDialog(
                             ) { onChange(widgetType.copy(imageTransitionMode = it)) }
                         }
                         if (widgetType.supportsPanZoom) {
-                            PanZoomConfig(enabled = widgetType.panZoomEnabled) { onChange(widgetType.copy(panZoomEnabled = it)) }
+                            PanZoomConfig(
+                                enabled = widgetType.panZoomEnabled,
+                            ) { onChange(widgetType.copy(panZoomEnabled = it)) }
                         }
                         ImageEffectsConfig(current = widgetType.effects) { onChange(widgetType.copy(effects = it)) }
                     }

--- a/app/src/test/java/com/esde/companion/data/log/ReactiveEsdeLogRepositoryTest.kt
+++ b/app/src/test/java/com/esde/companion/data/log/ReactiveEsdeLogRepositoryTest.kt
@@ -38,7 +38,9 @@ class ReactiveEsdeLogRepositoryTest {
             val repository =
                 ReactiveEsdeLogRepository(
                     logFolderPath = flowOf("/storage/emulated/0/ES-DE"),
-                    repositoryFactory = { folder -> FakeEsdeLogRepository(exists = folder == "/storage/emulated/0/ES-DE") },
+                    repositoryFactory = { folder ->
+                        FakeEsdeLogRepository(exists = folder == "/storage/emulated/0/ES-DE")
+                    },
                 )
 
             repository.observeLogFileExists().test {

--- a/app/src/test/java/com/esde/companion/data/settings/WidgetLayoutMappingTest.kt
+++ b/app/src/test/java/com/esde/companion/data/settings/WidgetLayoutMappingTest.kt
@@ -79,7 +79,12 @@ class WidgetLayoutMappingTest {
 
     @Test
     fun `SystemLogo round-trips logoTransitionMode and glintEnabled`() {
-        val widget = WidgetType.SystemLogo(ScaleMode.Fit, logoTransitionMode = LogoTransitionMode.Slide, glintEnabled = true)
+        val widget =
+            WidgetType.SystemLogo(
+                ScaleMode.Fit,
+                logoTransitionMode = LogoTransitionMode.Slide,
+                glintEnabled = true,
+            )
         assertEquals(widget, roundTrip(widget))
     }
 

--- a/app/src/test/java/com/esde/companion/domain/model/BuildDrawerItemsTest.kt
+++ b/app/src/test/java/com/esde/companion/domain/model/BuildDrawerItemsTest.kt
@@ -65,7 +65,8 @@ class BuildDrawerItemsTest {
 
     @Test
     fun `a hidden app is excluded from its folder but the folder itself still renders`() {
-        val folder = AppFolder(id = "folder-1", name = "Group", memberPackageNames = setOf(appA.packageName, appB.packageName))
+        val folder =
+            AppFolder(id = "folder-1", name = "Group", memberPackageNames = setOf(appA.packageName, appB.packageName))
 
         val result =
             buildDrawerItems(
@@ -79,7 +80,8 @@ class BuildDrawerItemsTest {
 
     @Test
     fun `an uninstalled member is silently dropped from a folder`() {
-        val folder = AppFolder(id = "folder-1", name = "Group", memberPackageNames = setOf(appA.packageName, "com.example.gone"))
+        val folder =
+            AppFolder(id = "folder-1", name = "Group", memberPackageNames = setOf(appA.packageName, "com.example.gone"))
 
         val result =
             buildDrawerItems(
@@ -103,7 +105,10 @@ class BuildDrawerItemsTest {
                 sortFoldersOnTop = false,
             )
 
-        assertEquals(listOf(DrawerItem.App(appB), DrawerItem.Folder(folder, listOf(appA))).sortedBy { it.label }, result)
+        assertEquals(
+            listOf(DrawerItem.App(appB), DrawerItem.Folder(folder, listOf(appA))).sortedBy { it.label },
+            result,
+        )
     }
 
     @Test

--- a/app/src/test/java/com/esde/companion/domain/model/WidgetContentResolverTest.kt
+++ b/app/src/test/java/com/esde/companion/domain/model/WidgetContentResolverTest.kt
@@ -41,7 +41,10 @@ class WidgetContentResolverTest {
                 fallbackBackgroundAssetPath = "fallback.webp",
             )
 
-        assertEquals(WidgetContent.Image("fallback.webp", ScaleMode.Fill, isTransparentOverlay = false, isAsset = true), content)
+        assertEquals(
+            WidgetContent.Image("fallback.webp", ScaleMode.Fill, isTransparentOverlay = false, isAsset = true),
+            content,
+        )
     }
 
     @Test
@@ -64,7 +67,10 @@ class WidgetContentResolverTest {
                 fallbackBackgroundAssetPath = "fallback.webp",
             )
 
-        assertEquals(WidgetContent.Image("/media/fanart.png", ScaleMode.Fill, isTransparentOverlay = false, isAsset = false), content)
+        assertEquals(
+            WidgetContent.Image("/media/fanart.png", ScaleMode.Fill, isTransparentOverlay = false, isAsset = false),
+            content,
+        )
     }
 
     // --- SystemMedia/GameMedia: unaffected background-fallback behavior ------------------
@@ -77,7 +83,10 @@ class WidgetContentResolverTest {
                 fallbackBackgroundAssetPath = "fallback.webp",
             )
 
-        assertEquals(WidgetContent.Image("fallback.webp", ScaleMode.Fill, isTransparentOverlay = false, isAsset = true), content)
+        assertEquals(
+            WidgetContent.Image("fallback.webp", ScaleMode.Fill, isTransparentOverlay = false, isAsset = true),
+            content,
+        )
     }
 
     @Test
@@ -88,7 +97,10 @@ class WidgetContentResolverTest {
                 fallbackBackgroundAssetPath = "fallback.webp",
             )
 
-        assertEquals(WidgetContent.Image("fallback.webp", ScaleMode.Fill, isTransparentOverlay = false, isAsset = true), content)
+        assertEquals(
+            WidgetContent.Image("fallback.webp", ScaleMode.Fill, isTransparentOverlay = false, isAsset = true),
+            content,
+        )
     }
 
     @Test
@@ -183,7 +195,10 @@ class WidgetContentResolverTest {
                 },
             )
 
-        assertEquals(WidgetContent.Image("/media/fanart.png", ScaleMode.Fill, isTransparentOverlay = false, isAsset = false), content)
+        assertEquals(
+            WidgetContent.Image("/media/fanart.png", ScaleMode.Fill, isTransparentOverlay = false, isAsset = false),
+            content,
+        )
     }
 
     // --- SystemLogo: name-text fallback ---------------------------------------------------
@@ -215,7 +230,10 @@ class WidgetContentResolverTest {
                 systemNameLookup = { "Sega Dreamcast" },
             )
 
-        assertEquals(WidgetContent.SystemLogoAsset("file:///android_asset/system_logos/dreamcast.svg", ScaleMode.Fit), content)
+        assertEquals(
+            WidgetContent.SystemLogoAsset("file:///android_asset/system_logos/dreamcast.svg", ScaleMode.Fit),
+            content,
+        )
     }
 
     // --- CustomImage: fixed user-picked path, independent of any lookup -------------------
@@ -224,11 +242,20 @@ class WidgetContentResolverTest {
     fun `CustomImage resolves to the widget's own fixed path`() {
         val content =
             resolve(
-                widgetType = WidgetType.CustomImage(path = "/storage/emulated/0/Pictures/cover.jpg", scaleMode = ScaleMode.Fill),
+                widgetType =
+                    WidgetType.CustomImage(
+                        path = "/storage/emulated/0/Pictures/cover.jpg",
+                        scaleMode = ScaleMode.Fill,
+                    ),
             )
 
         assertEquals(
-            WidgetContent.Image("/storage/emulated/0/Pictures/cover.jpg", ScaleMode.Fill, isTransparentOverlay = false, isAsset = false),
+            WidgetContent.Image(
+                "/storage/emulated/0/Pictures/cover.jpg",
+                ScaleMode.Fill,
+                isTransparentOverlay = false,
+                isAsset = false,
+            ),
             content,
         )
     }
@@ -280,7 +307,10 @@ class WidgetContentResolverTest {
                 gameNameLookup = { "Crazy Taxi" },
             )
 
-        assertEquals(WidgetContent.Image("/media/marquee.png", ScaleMode.Fit, isTransparentOverlay = true, isAsset = false), content)
+        assertEquals(
+            WidgetContent.Image("/media/marquee.png", ScaleMode.Fit, isTransparentOverlay = true, isAsset = false),
+            content,
+        )
     }
 
     // --- Rating: 0f..1f -> 0f..5f star conversion and no-rating behavior ------------------

--- a/app/src/test/java/com/esde/companion/domain/model/WidgetImageTransitionEligibilityTest.kt
+++ b/app/src/test/java/com/esde/companion/domain/model/WidgetImageTransitionEligibilityTest.kt
@@ -79,13 +79,23 @@ class WidgetImageTransitionEligibilityTest {
 
     @Test
     fun `imageTransitionActive forces None for box-art GameMedia even when Fill-scaled and Fade stored`() {
-        val widget = WidgetType.GameMedia(MediaType.Covers, ScaleMode.Fill, imageTransitionMode = ImageTransitionMode.Fade)
+        val widget =
+            WidgetType.GameMedia(
+                MediaType.Covers,
+                ScaleMode.Fill,
+                imageTransitionMode = ImageTransitionMode.Fade,
+            )
         assertEquals(ImageTransitionMode.None, widget.imageTransitionActive)
     }
 
     @Test
     fun `imageTransitionActive is the stored mode for eligible GameMedia`() {
-        val widget = WidgetType.GameMedia(MediaType.Screenshots, ScaleMode.Fill, imageTransitionMode = ImageTransitionMode.Fade)
+        val widget =
+            WidgetType.GameMedia(
+                MediaType.Screenshots,
+                ScaleMode.Fill,
+                imageTransitionMode = ImageTransitionMode.Fade,
+            )
         assertEquals(ImageTransitionMode.Fade, widget.imageTransitionActive)
     }
 
@@ -99,15 +109,27 @@ class WidgetImageTransitionEligibilityTest {
         )
         assertEquals(
             ImageTransitionMode.Fade,
-            WidgetType.CustomImage("p", ScaleMode.Fill, imageTransitionMode = ImageTransitionMode.Fade).imageTransitionMode,
+            WidgetType.CustomImage(
+                "p",
+                ScaleMode.Fill,
+                imageTransitionMode = ImageTransitionMode.Fade,
+            ).imageTransitionMode,
         )
         assertEquals(
             ImageTransitionMode.Fade,
-            WidgetType.SystemMedia(MediaType.FanArt, ScaleMode.Fill, imageTransitionMode = ImageTransitionMode.Fade).imageTransitionMode,
+            WidgetType.SystemMedia(
+                MediaType.FanArt,
+                ScaleMode.Fill,
+                imageTransitionMode = ImageTransitionMode.Fade,
+            ).imageTransitionMode,
         )
         assertEquals(
             ImageTransitionMode.Fade,
-            WidgetType.GameMedia(MediaType.Screenshots, ScaleMode.Fill, imageTransitionMode = ImageTransitionMode.Fade).imageTransitionMode,
+            WidgetType.GameMedia(
+                MediaType.Screenshots,
+                ScaleMode.Fill,
+                imageTransitionMode = ImageTransitionMode.Fade,
+            ).imageTransitionMode,
         )
         assertEquals(ImageTransitionMode.None, WidgetType.SystemLogo(ScaleMode.Fill).imageTransitionMode)
         assertEquals(ImageTransitionMode.None, WidgetType.ColorBackground(0xFF000000, 1f).imageTransitionMode)
@@ -115,7 +137,12 @@ class WidgetImageTransitionEligibilityTest {
 
     @Test
     fun `logoTransitionMode and glintEnabled read through for every logo-style variant`() {
-        val logo = WidgetType.SystemLogo(ScaleMode.Fill, logoTransitionMode = LogoTransitionMode.Slide, glintEnabled = true)
+        val logo =
+            WidgetType.SystemLogo(
+                ScaleMode.Fill,
+                logoTransitionMode = LogoTransitionMode.Slide,
+                glintEnabled = true,
+            )
         assertEquals(LogoTransitionMode.Slide, logo.logoTransitionMode)
         assertTrue(logo.glintEnabled)
 

--- a/app/src/test/java/com/esde/companion/domain/music/MusicPlaybackCoordinatorTest.kt
+++ b/app/src/test/java/com/esde/companion/domain/music/MusicPlaybackCoordinatorTest.kt
@@ -266,7 +266,11 @@ class MusicPlaybackCoordinatorTest {
         onPlaybackError: (MusicTrack?, String) -> Unit = { _, _ -> },
     ): MusicPlaybackCoordinator {
         val logRepository = FakeEsdeLogRepository(events)
-        val observeConnectionState = ObserveConnectionStateUseCase(logRepository, ObserveAppStateUseCase(logRepository, scope))
+        val observeConnectionState =
+            ObserveConnectionStateUseCase(
+                logRepository,
+                ObserveAppStateUseCase(logRepository, scope),
+            )
         return MusicPlaybackCoordinator(
             observeConnectionState = observeConnectionState,
             observeMusicEnabled = ObserveMusicEnabledUseCase(onboardingRepository),
@@ -475,7 +479,10 @@ class MusicPlaybackCoordinatorTest {
             val trackA2 = MusicTrack("/music/systems/a/2.mp3", "2")
             val library =
                 FakeMusicLibraryRepository(
-                    poolsByRequestedSystem = mapOf("a" to MusicPoolContents(MusicPool.PerSystem("a"), listOf(trackA1, trackA2))),
+                    poolsByRequestedSystem =
+                        mapOf(
+                            "a" to MusicPoolContents(MusicPool.PerSystem("a"), listOf(trackA1, trackA2)),
+                        ),
                     generalPool = MusicPoolContents(MusicPool.General, emptyList()),
                 )
             val controller = FakeMusicPlayerController()
@@ -505,7 +512,10 @@ class MusicPlaybackCoordinatorTest {
             val trackA2 = MusicTrack("/music/systems/a/2.mp3", "2")
             val library =
                 FakeMusicLibraryRepository(
-                    poolsByRequestedSystem = mapOf("a" to MusicPoolContents(MusicPool.PerSystem("a"), listOf(trackA1, trackA2))),
+                    poolsByRequestedSystem =
+                        mapOf(
+                            "a" to MusicPoolContents(MusicPool.PerSystem("a"), listOf(trackA1, trackA2)),
+                        ),
                     generalPool = MusicPoolContents(MusicPool.General, emptyList()),
                 )
             val controller = FakeMusicPlayerController()
@@ -535,7 +545,10 @@ class MusicPlaybackCoordinatorTest {
             val trackA2 = MusicTrack("/music/systems/a/2.mp3", "2")
             val library =
                 FakeMusicLibraryRepository(
-                    poolsByRequestedSystem = mapOf("a" to MusicPoolContents(MusicPool.PerSystem("a"), listOf(trackA1, trackA2))),
+                    poolsByRequestedSystem =
+                        mapOf(
+                            "a" to MusicPoolContents(MusicPool.PerSystem("a"), listOf(trackA1, trackA2)),
+                        ),
                     generalPool = MusicPoolContents(MusicPool.General, emptyList()),
                 )
             val controller = FakeMusicPlayerController()

--- a/app/src/test/java/com/esde/companion/domain/parser/EsdeEventParserTest.kt
+++ b/app/src/test/java/com/esde/companion/domain/parser/EsdeEventParserTest.kt
@@ -69,7 +69,8 @@ class EsdeEventParserTest {
     fun `parses game-start with shell-escaped path and unescapes it`() {
         val line =
             "Jul 28 10:01:54 Debug:  Scripting::fireEvent(): game-start " +
-                "\"/storage/E2AB-E84A/ROMs/gba/Mega\\ Man\\ Battle\\ Network\\ 3\\ -\\ White\\ Version\\ \\(USA\\).zip\" " +
+                "\"/storage/E2AB-E84A/ROMs/gba/Mega\\ Man\\ Battle\\ Network\\ 3\\ -\\ White\\ Version\\ " +
+                "\\(USA\\).zip\" " +
                 "\"Mega Man Battle Network 3 : White\" \"gba\" \"Nintendo Game Boy Advance\""
 
         val result = parser.parseLine(line)

--- a/app/src/test/java/com/esde/companion/domain/parser/NavigationDirectionParserTest.kt
+++ b/app/src/test/java/com/esde/companion/domain/parser/NavigationDirectionParserTest.kt
@@ -15,37 +15,43 @@ import org.junit.Test
 class NavigationDirectionParserTest {
     @Test
     fun `parses up press`() {
-        val line = "Aug 02 13:31:33 Debug:  Window::logInput(Xbox Wireless Controller): Button 11, isMappedTo=up, value=1"
+        val line =
+            "Aug 02 13:31:33 Debug:  Window::logInput(Xbox Wireless Controller): Button 11, isMappedTo=up, value=1"
         assertEquals(NavigationDirection.Up, NavigationDirectionParser.parseDirectionalPress(line))
     }
 
     @Test
     fun `parses down press`() {
-        val line = "Aug 02 13:31:31 Debug:  Window::logInput(Xbox Wireless Controller): Button 12, isMappedTo=down, value=1"
+        val line =
+            "Aug 02 13:31:31 Debug:  Window::logInput(Xbox Wireless Controller): Button 12, isMappedTo=down, value=1"
         assertEquals(NavigationDirection.Down, NavigationDirectionParser.parseDirectionalPress(line))
     }
 
     @Test
     fun `parses left press`() {
-        val line = "Aug 02 13:31:35 Debug:  Window::logInput(Xbox Wireless Controller): Button 13, isMappedTo=left, value=1"
+        val line =
+            "Aug 02 13:31:35 Debug:  Window::logInput(Xbox Wireless Controller): Button 13, isMappedTo=left, value=1"
         assertEquals(NavigationDirection.Left, NavigationDirectionParser.parseDirectionalPress(line))
     }
 
     @Test
     fun `parses right press`() {
-        val line = "Aug 02 13:31:34 Debug:  Window::logInput(Xbox Wireless Controller): Button 14, isMappedTo=right, value=1"
+        val line =
+            "Aug 02 13:31:34 Debug:  Window::logInput(Xbox Wireless Controller): Button 14, isMappedTo=right, value=1"
         assertEquals(NavigationDirection.Right, NavigationDirectionParser.parseDirectionalPress(line))
     }
 
     @Test
     fun `release returns null`() {
-        val line = "Aug 02 13:31:33 Debug:  Window::logInput(Xbox Wireless Controller): Button 11, isMappedTo=up, value=0"
+        val line =
+            "Aug 02 13:31:33 Debug:  Window::logInput(Xbox Wireless Controller): Button 11, isMappedTo=up, value=0"
         assertNull(NavigationDirectionParser.parseDirectionalPress(line))
     }
 
     @Test
     fun `release with trailing space returns null`() {
-        val line = "Aug 02 13:31:33 Debug:  Window::logInput(Xbox Wireless Controller): Button 11, isMappedTo=up, value=0 "
+        val line =
+            "Aug 02 13:31:33 Debug:  Window::logInput(Xbox Wireless Controller): Button 11, isMappedTo=up, value=0 "
         assertNull(NavigationDirectionParser.parseDirectionalPress(line))
     }
 
@@ -63,7 +69,9 @@ class NavigationDirectionParserTest {
 
     @Test
     fun `fireEvent line is not a logInput line`() {
-        val line = "Aug 02 13:31:34 Debug:  Scripting::fireEvent(): game-select \"/roms/game.zip\" \"Game\" \"nes\" \"Nintendo\""
+        val line =
+            "Aug 02 13:31:34 Debug:  Scripting::fireEvent(): game-select \"/roms/game.zip\" \"Game\" \"nes\" " +
+                "\"Nintendo\""
         assertFalse(NavigationDirectionParser.isLogInputLine(line))
         assertNull(NavigationDirectionParser.parseDirectionalPress(line))
     }
@@ -92,7 +100,9 @@ class NavigationDirectionParserTest {
 
     @Test
     fun `unrecognized mapped name is well-formed but not a direction`() {
-        val line = "Aug 02 13:31:34 Debug:  Window::logInput(Xbox Wireless Controller): Button 4, isMappedTo=leftshoulder, value=1"
+        val line =
+            "Aug 02 13:31:34 Debug:  Window::logInput(Xbox Wireless Controller): Button 4, " +
+                "isMappedTo=leftshoulder, value=1"
         assertTrue(NavigationDirectionParser.isWellFormedInputLine(line))
         assertNull(NavigationDirectionParser.parseDirectionalPress(line))
     }

--- a/app/src/test/java/com/esde/companion/domain/parser/NavigationDirectionTrackerTest.kt
+++ b/app/src/test/java/com/esde/companion/domain/parser/NavigationDirectionTrackerTest.kt
@@ -60,12 +60,17 @@ class NavigationDirectionTrackerTest {
     @Test
     fun `b-triggered system-select carries no direction, reproducing the real log excerpt`() {
         tracker.observeLine("Window::logInput(Xbox Wireless Controller): Button 11, isMappedTo=up, value=1")
-        tracker.observeLine("Scripting::fireEvent(): game-select \"/roms/game.zip\" \"Buggy Run\" \"mastersystem\" \"Sega Master System\"")
+        tracker.observeLine(
+            "Scripting::fireEvent(): game-select \"/roms/game.zip\" \"Buggy Run\" \"mastersystem\" " +
+                "\"Sega Master System\"",
+        )
         tracker.observeLine("Window::logInput(Xbox Wireless Controller): Button 11, isMappedTo=up, value=0")
         tracker.observeLine("Window::logInput(Xbox Wireless Controller): Button 1, isMappedTo=b, value=1")
         // At this point, the direction for the following system-select must be null.
         assertNull(tracker.direction)
-        tracker.observeLine("Scripting::fireEvent(): system-select \"mastersystem\" \"Sega Master System\" \"/roms/mastersystem\" \"\"")
+        tracker.observeLine(
+            "Scripting::fireEvent(): system-select \"mastersystem\" \"Sega Master System\" \"/roms/mastersystem\" \"\"",
+        )
         assertNull(tracker.direction)
     }
 

--- a/app/src/test/java/com/esde/companion/domain/state/AppStateReducerTest.kt
+++ b/app/src/test/java/com/esde/companion/domain/state/AppStateReducerTest.kt
@@ -35,24 +35,48 @@ class AppStateReducerTest {
 
     @Test
     fun `system-select carries the event's navigation direction into BrowsingSystem`() {
-        val event = EsdeEvent.SystemSelect("dreamcast", "Sega Dreamcast", "/roms/dreamcast", direction = NavigationDirection.Right)
+        val event =
+            EsdeEvent.SystemSelect(
+                "dreamcast",
+                "Sega Dreamcast",
+                "/roms/dreamcast",
+                direction = NavigationDirection.Right,
+            )
 
         val result = AppStateReducer.reduce(AppState.Idle, event)
 
         assertEquals(
-            AppState.BrowsingSystem("dreamcast", "Sega Dreamcast", "/roms/dreamcast", navigationDirection = NavigationDirection.Right),
+            AppState.BrowsingSystem(
+                "dreamcast",
+                "Sega Dreamcast",
+                "/roms/dreamcast",
+                navigationDirection = NavigationDirection.Right,
+            ),
             result,
         )
     }
 
     @Test
     fun `game-select carries the event's navigation direction into BrowsingGame`() {
-        val event = EsdeEvent.GameSelect("/roms/dc/game.chd", "Game", "dreamcast", "Sega Dreamcast", direction = NavigationDirection.Up)
+        val event =
+            EsdeEvent.GameSelect(
+                "/roms/dc/game.chd",
+                "Game",
+                "dreamcast",
+                "Sega Dreamcast",
+                direction = NavigationDirection.Up,
+            )
 
         val result = AppStateReducer.reduce(AppState.Idle, event)
 
         assertEquals(
-            AppState.BrowsingGame("/roms/dc/game.chd", "Game", "dreamcast", "Sega Dreamcast", navigationDirection = NavigationDirection.Up),
+            AppState.BrowsingGame(
+                "/roms/dc/game.chd",
+                "Game",
+                "dreamcast",
+                "Sega Dreamcast",
+                navigationDirection = NavigationDirection.Up,
+            ),
             result,
         )
     }
@@ -156,7 +180,7 @@ class AppStateReducerTest {
     }
 
     @Test
-    fun `screensaver-game-select without a prior screensaver-start falls back to unknown mode and Idle previousState`() {
+    fun `screensaver-game-select without prior screensaver-start falls back to unknown mode, Idle previousState`() {
         val event = EsdeEvent.ScreensaverGameSelect("/roms/arcade/tapper.zip", "Tapper", "arcade", "Arcade")
 
         val result = AppStateReducer.reduce(AppState.Idle, event)

--- a/app/src/test/java/com/esde/companion/ui/dock/AppDockViewModelTest.kt
+++ b/app/src/test/java/com/esde/companion/ui/dock/AppDockViewModelTest.kt
@@ -338,7 +338,8 @@ class AppDockViewModelTest {
     @Test
     fun `removeFromDock filters the package and closes the gap`() =
         runTest(testDispatcher) {
-            val repository = FakeDockSettingsRepository(initialDockApps = listOf("com.example.a", "com.example.b", "com.example.c"))
+            val repository =
+                FakeDockSettingsRepository(initialDockApps = listOf("com.example.a", "com.example.b", "com.example.c"))
             val viewModel = buildViewModel(dockSettingsRepository = repository)
 
             viewModel.removeFromDock("com.example.b")
@@ -350,7 +351,8 @@ class AppDockViewModelTest {
     @Test
     fun `moveLeft swaps with the previous entry and no-ops at the start`() =
         runTest(testDispatcher) {
-            val repository = FakeDockSettingsRepository(initialDockApps = listOf("com.example.a", "com.example.b", "com.example.c"))
+            val repository =
+                FakeDockSettingsRepository(initialDockApps = listOf("com.example.a", "com.example.b", "com.example.c"))
             val viewModel = buildViewModel(dockSettingsRepository = repository)
 
             viewModel.moveLeft("com.example.b")
@@ -365,7 +367,8 @@ class AppDockViewModelTest {
     @Test
     fun `moveRight swaps with the next entry and no-ops at the end`() =
         runTest(testDispatcher) {
-            val repository = FakeDockSettingsRepository(initialDockApps = listOf("com.example.a", "com.example.b", "com.example.c"))
+            val repository =
+                FakeDockSettingsRepository(initialDockApps = listOf("com.example.a", "com.example.b", "com.example.c"))
             val viewModel = buildViewModel(dockSettingsRepository = repository)
 
             viewModel.moveRight("com.example.b")

--- a/app/src/test/java/com/esde/companion/ui/drawer/AppDrawerViewModelTest.kt
+++ b/app/src/test/java/com/esde/companion/ui/drawer/AppDrawerViewModelTest.kt
@@ -376,7 +376,11 @@ class AppDrawerViewModelTest {
             // sortFoldersOnTop defaults to true, so the folder comes first regardless of
             // where "Group" would otherwise fall alphabetically among "App B"/"App C".
             assertEquals(
-                listOf(DrawerItem.Folder(folder, listOf(allApps[0])), DrawerItem.App(allApps[1]), DrawerItem.App(allApps[2])),
+                listOf(
+                    DrawerItem.Folder(folder, listOf(allApps[0])),
+                    DrawerItem.App(allApps[1]),
+                    DrawerItem.App(allApps[2]),
+                ),
                 viewModel.drawerItems.value,
             )
             collectJob.cancel()
@@ -395,7 +399,11 @@ class AppDrawerViewModelTest {
 
             // "App B"/"App C" sort before "Group" (the folder's name) alphabetically.
             assertEquals(
-                listOf(DrawerItem.App(allApps[1]), DrawerItem.App(allApps[2]), DrawerItem.Folder(folder, listOf(allApps[0]))),
+                listOf(
+                    DrawerItem.App(allApps[1]),
+                    DrawerItem.App(allApps[2]),
+                    DrawerItem.Folder(folder, listOf(allApps[0])),
+                ),
                 viewModel.drawerItems.value,
             )
             collectJob.cancel()
@@ -434,7 +442,12 @@ class AppDrawerViewModelTest {
     @Test
     fun `removeAppFromFolder shrinks a multi-member folder without deleting it`() =
         runTest(testDispatcher) {
-            val folder = AppFolder(id = "folder-1", name = "Group", memberPackageNames = setOf("com.example.a", "com.example.b"))
+            val folder =
+                AppFolder(
+                    id = "folder-1",
+                    name = "Group",
+                    memberPackageNames = setOf("com.example.a", "com.example.b"),
+                )
             val folderRepository = FakeAppFolderRepository(initialFolders = listOf(folder))
             val viewModel = buildViewModel(folderRepository = folderRepository)
 
@@ -505,7 +518,10 @@ class AppDrawerViewModelTest {
     @Test
     fun `otherScreenLaunchApps reflects the repository value`() =
         runTest(testDispatcher) {
-            val settingsRepository = FakeAppDrawerSettingsRepository(initialOtherScreenLaunchApps = setOf("com.example.a"))
+            val settingsRepository =
+                FakeAppDrawerSettingsRepository(
+                    initialOtherScreenLaunchApps = setOf("com.example.a"),
+                )
             val viewModel = buildViewModel(settingsRepository = settingsRepository)
 
             val collectJob = launch { viewModel.otherScreenLaunchApps.collect {} }

--- a/app/src/test/java/com/esde/companion/ui/onboarding/OnboardingViewModelTest.kt
+++ b/app/src/test/java/com/esde/companion/ui/onboarding/OnboardingViewModelTest.kt
@@ -217,7 +217,9 @@ class OnboardingViewModelTest {
 
         override suspend fun readMediaDirectory(esdeRootPath: String): String? = mediaDirectory
 
-        override suspend fun readEventScriptSettings(esdeRootPath: String): EsdeEventScriptSettings? = eventScriptSettings
+        override suspend fun readEventScriptSettings(esdeRootPath: String): EsdeEventScriptSettings? {
+            return eventScriptSettings
+        }
 
         override fun observeEventScriptSettings(esdeRootPath: String): Flow<EsdeEventScriptSettings?> =
             flow {
@@ -289,7 +291,10 @@ class OnboardingViewModelTest {
             // Valid and ready to go, but the user hasn't actually confirmed anything yet -
             // this is just the default guess, never explicitly chosen.
             assertEquals(OnboardingStep.EsdeFolder, viewModel.uiState.value.step)
-            assertEquals(LogFolderValidation.FolderFound(settingsFileFound = true), viewModel.uiState.value.logFolderValidation)
+            assertEquals(
+                LogFolderValidation.FolderFound(settingsFileFound = true),
+                viewModel.uiState.value.logFolderValidation,
+            )
             assertTrue(onboardingRepo.savedLogPaths.isEmpty())
 
             viewModel.onEsdeFolderConfirmed()
@@ -342,7 +347,8 @@ class OnboardingViewModelTest {
                 FakeEsdeInstallationRepository().apply {
                     mediaDirectory = "/storage/emulated/0/ES-DE/downloaded_media"
                 }
-            val viewModel = buildViewModel(onboardingRepository = onboardingRepo, installationRepository = installationRepo)
+            val viewModel =
+                buildViewModel(onboardingRepository = onboardingRepo, installationRepository = installationRepo)
             advanceUntilIdle()
             viewModel.onEsdeFolderConfirmed()
             advanceUntilIdle()
@@ -363,7 +369,8 @@ class OnboardingViewModelTest {
                 FakeEsdeInstallationRepository().apply {
                     mediaDirectory = "/storage/emulated/0/ES-DE/downloaded_media"
                 }
-            val viewModel = buildViewModel(onboardingRepository = onboardingRepo, installationRepository = installationRepo)
+            val viewModel =
+                buildViewModel(onboardingRepository = onboardingRepo, installationRepository = installationRepo)
             advanceUntilIdle()
             viewModel.onEsdeFolderConfirmed()
             advanceUntilIdle()

--- a/app/src/test/java/com/esde/companion/ui/settings/SettingsViewModelTest.kt
+++ b/app/src/test/java/com/esde/companion/ui/settings/SettingsViewModelTest.kt
@@ -515,15 +515,27 @@ class SettingsViewModelTest {
                 setDockSizeUseCase = SetDockSizeUseCase(dockSettingsRepository),
                 observeMusicEnabledUseCase = ObserveMusicEnabledUseCase(onboardingRepository),
                 setMusicEnabledUseCase = SetMusicEnabledUseCase(onboardingRepository),
-                observeMusicPlayWhileBrowsingSystemsUseCase = ObserveMusicPlayWhileBrowsingSystemsUseCase(onboardingRepository),
+                observeMusicPlayWhileBrowsingSystemsUseCase =
+                    ObserveMusicPlayWhileBrowsingSystemsUseCase(
+                        onboardingRepository,
+                    ),
                 setMusicPlayWhileBrowsingSystemsUseCase = SetMusicPlayWhileBrowsingSystemsUseCase(onboardingRepository),
-                observeMusicPlayWhileBrowsingGamesUseCase = ObserveMusicPlayWhileBrowsingGamesUseCase(onboardingRepository),
+                observeMusicPlayWhileBrowsingGamesUseCase =
+                    ObserveMusicPlayWhileBrowsingGamesUseCase(
+                        onboardingRepository,
+                    ),
                 setMusicPlayWhileBrowsingGamesUseCase = SetMusicPlayWhileBrowsingGamesUseCase(onboardingRepository),
-                observeMusicPlayDuringScreensaverUseCase = ObserveMusicPlayDuringScreensaverUseCase(onboardingRepository),
+                observeMusicPlayDuringScreensaverUseCase =
+                    ObserveMusicPlayDuringScreensaverUseCase(
+                        onboardingRepository,
+                    ),
                 setMusicPlayDuringScreensaverUseCase = SetMusicPlayDuringScreensaverUseCase(onboardingRepository),
                 observeMusicDuckingModeUseCase = ObserveMusicDuckingModeUseCase(onboardingRepository),
                 setMusicDuckingModeUseCase = SetMusicDuckingModeUseCase(onboardingRepository),
-                observeCloseCompanionOnQuitEnabledUseCase = ObserveCloseCompanionOnQuitEnabledUseCase(onboardingRepository),
+                observeCloseCompanionOnQuitEnabledUseCase =
+                    ObserveCloseCompanionOnQuitEnabledUseCase(
+                        onboardingRepository,
+                    ),
                 setCloseCompanionOnQuitEnabledUseCase = SetCloseCompanionOnQuitEnabledUseCase(onboardingRepository),
                 observeFabAssignmentsUseCase = ObserveFabAssignmentsUseCase(onboardingRepository),
                 setFabAssignmentUseCase = SetFabAssignmentUseCase(onboardingRepository),

--- a/app/src/test/java/com/esde/companion/ui/widgets/edit/EditWidgetsViewModelTest.kt
+++ b/app/src/test/java/com/esde/companion/ui/widgets/edit/EditWidgetsViewModelTest.kt
@@ -464,7 +464,10 @@ class EditWidgetsViewModelTest {
                 FakeWidgetLayoutRepository().apply {
                     seed(
                         StateGroup.System,
-                        listOf(placedWidget(id = "existing-a", zIndex = 0), placedWidget(id = "existing-b", zIndex = 3)),
+                        listOf(
+                            placedWidget(id = "existing-a", zIndex = 0),
+                            placedWidget(id = "existing-b", zIndex = 3),
+                        ),
                     )
                 }
             val viewModel = buildViewModel(widgetLayoutRepository = repository)
@@ -566,7 +569,10 @@ class EditWidgetsViewModelTest {
         runTest(testDispatcher) {
             val repository =
                 FakeWidgetLayoutRepository().apply {
-                    seed(StateGroup.System, listOf(placedWidget(id = "widget-a", zIndex = 0), placedWidget(id = "widget-b", zIndex = 1)))
+                    seed(
+                        StateGroup.System,
+                        listOf(placedWidget(id = "widget-a", zIndex = 0), placedWidget(id = "widget-b", zIndex = 1)),
+                    )
                 }
             val viewModel = buildViewModel(widgetLayoutRepository = repository)
             viewModel.setGridDimensions(grid)
@@ -585,7 +591,10 @@ class EditWidgetsViewModelTest {
         runTest(testDispatcher) {
             val repository =
                 FakeWidgetLayoutRepository().apply {
-                    seed(StateGroup.System, listOf(placedWidget(id = "widget-a", zIndex = 0), placedWidget(id = "widget-b", zIndex = 1)))
+                    seed(
+                        StateGroup.System,
+                        listOf(placedWidget(id = "widget-a", zIndex = 0), placedWidget(id = "widget-b", zIndex = 1)),
+                    )
                 }
             val viewModel = buildViewModel(widgetLayoutRepository = repository)
             viewModel.setGridDimensions(grid)
@@ -650,7 +659,16 @@ class EditWidgetsViewModelTest {
                 FakeWidgetLayoutRepository().apply {
                     seed(
                         StateGroup.System,
-                        listOf(placedWidget(id = "widget-a", gridColumn = 5, gridRow = 0, columnSpan = 5, rowSpan = 10, zIndex = 0)),
+                        listOf(
+                            placedWidget(
+                                id = "widget-a",
+                                gridColumn = 5,
+                                gridRow = 0,
+                                columnSpan = 5,
+                                rowSpan = 10,
+                                zIndex = 0,
+                            ),
+                        ),
                         grid = GridDimensions(columns = 10, rows = 10),
                     )
                 }
@@ -676,7 +694,16 @@ class EditWidgetsViewModelTest {
                 FakeWidgetLayoutRepository().apply {
                     seed(
                         StateGroup.System,
-                        listOf(placedWidget(id = "widget-a", gridColumn = 5, gridRow = 0, columnSpan = 5, rowSpan = 10, zIndex = 0)),
+                        listOf(
+                            placedWidget(
+                                id = "widget-a",
+                                gridColumn = 5,
+                                gridRow = 0,
+                                columnSpan = 5,
+                                rowSpan = 10,
+                                zIndex = 0,
+                            ),
+                        ),
                         // grid omitted - defaults to null, same as data persisted before this feature existed.
                     )
                 }
@@ -734,7 +761,10 @@ class EditWidgetsViewModelTest {
         runTest(testDispatcher) {
             val repository =
                 FakeWidgetLayoutRepository().apply {
-                    seed(StateGroup.System, listOf(placedWidget(id = "widget-a", zIndex = 0, gridColumn = 1, gridRow = 1)))
+                    seed(
+                        StateGroup.System,
+                        listOf(placedWidget(id = "widget-a", zIndex = 0, gridColumn = 1, gridRow = 1)),
+                    )
                 }
             val viewModel = buildViewModel(widgetLayoutRepository = repository)
             viewModel.setGridDimensions(grid)
@@ -763,7 +793,13 @@ class EditWidgetsViewModelTest {
                 FakeWidgetLayoutRepository().apply {
                     seed(
                         StateGroup.System,
-                        listOf(placedWidget(id = "widget-a", zIndex = 0, widgetType = WidgetType.SystemLogo(ScaleMode.Fit))),
+                        listOf(
+                            placedWidget(
+                                id = "widget-a",
+                                zIndex = 0,
+                                widgetType = WidgetType.SystemLogo(ScaleMode.Fit),
+                            ),
+                        ),
                     )
                 }
             val viewModel = buildViewModel(widgetLayoutRepository = repository)

--- a/config/detekt/baseline.xml
+++ b/config/detekt/baseline.xml
@@ -2,141 +2,6 @@
 <SmellBaseline>
   <ManuallySuppressedIssues></ManuallySuppressedIssues>
   <CurrentIssues>
-    <ID>ArgumentListWrapping:AppDock.kt$(alpha = 0.3f)</ID>
-    <ID>ArgumentListWrapping:AppDock.kt$(context)</ID>
-    <ID>ArgumentListWrapping:AppDock.kt$(context, app.packageName, displayId = SecondaryDisplayResolver.secondaryDisplayId(context))</ID>
-    <ID>ArgumentListWrapping:AppDockViewModel.kt$AppDockViewModel$(scope = viewModelScope, started = SharingStarted.WhileSubscribed(stopTimeoutMillis = 5_000), initialValue = 5)</ID>
-    <ID>ArgumentListWrapping:AppDockViewModel.kt$AppDockViewModel$(scope = viewModelScope, started = SharingStarted.WhileSubscribed(stopTimeoutMillis = 5_000), initialValue = 80)</ID>
-    <ID>ArgumentListWrapping:AppDockViewModel.kt$AppDockViewModel$(scope = viewModelScope, started = SharingStarted.WhileSubscribed(stopTimeoutMillis = 5_000), initialValue = emptyList())</ID>
-    <ID>ArgumentListWrapping:AppDockViewModel.kt$AppDockViewModel$(scope = viewModelScope, started = SharingStarted.WhileSubscribed(stopTimeoutMillis = 5_000), initialValue = emptySet())</ID>
-    <ID>ArgumentListWrapping:AppDockViewModel.kt$AppDockViewModel$(scope = viewModelScope, started = SharingStarted.WhileSubscribed(stopTimeoutMillis = 5_000), initialValue = false)</ID>
-    <ID>ArgumentListWrapping:AppDockViewModel.kt$AppDockViewModel$(stopTimeoutMillis = 5_000)</ID>
-    <ID>ArgumentListWrapping:AppDockViewModelTest.kt$AppDockViewModelTest$("com.example.a", "com.example.b", "com.example.c")</ID>
-    <ID>ArgumentListWrapping:AppDockViewModelTest.kt$AppDockViewModelTest$(initialDockApps = listOf("com.example.a", "com.example.b", "com.example.c"))</ID>
-    <ID>ArgumentListWrapping:AppDrawerViewModel.kt$AppDrawerViewModel$(id = UUID.randomUUID().toString(), name = name, memberPackageNames = setOf(packageName))</ID>
-    <ID>ArgumentListWrapping:AppDrawerViewModel.kt$AppDrawerViewModel$(packageName)</ID>
-    <ID>ArgumentListWrapping:AppDrawerViewModelTest.kt$AppDrawerViewModelTest$("com.example.a")</ID>
-    <ID>ArgumentListWrapping:AppDrawerViewModelTest.kt$AppDrawerViewModelTest$("com.example.a", "com.example.b")</ID>
-    <ID>ArgumentListWrapping:AppDrawerViewModelTest.kt$AppDrawerViewModelTest$(DrawerItem.App(allApps[1]), DrawerItem.App(allApps[2]), DrawerItem.Folder(folder, listOf(allApps[0])))</ID>
-    <ID>ArgumentListWrapping:AppDrawerViewModelTest.kt$AppDrawerViewModelTest$(DrawerItem.Folder(folder, listOf(allApps[0])), DrawerItem.App(allApps[1]), DrawerItem.App(allApps[2]))</ID>
-    <ID>ArgumentListWrapping:AppDrawerViewModelTest.kt$AppDrawerViewModelTest$(allApps[0])</ID>
-    <ID>ArgumentListWrapping:AppDrawerViewModelTest.kt$AppDrawerViewModelTest$(allApps[1])</ID>
-    <ID>ArgumentListWrapping:AppDrawerViewModelTest.kt$AppDrawerViewModelTest$(allApps[2])</ID>
-    <ID>ArgumentListWrapping:AppDrawerViewModelTest.kt$AppDrawerViewModelTest$(folder, listOf(allApps[0]))</ID>
-    <ID>ArgumentListWrapping:AppDrawerViewModelTest.kt$AppDrawerViewModelTest$(id = "folder-1", name = "Group", memberPackageNames = setOf("com.example.a", "com.example.b"))</ID>
-    <ID>ArgumentListWrapping:AppDrawerViewModelTest.kt$AppDrawerViewModelTest$(initialOtherScreenLaunchApps = setOf("com.example.a"))</ID>
-    <ID>ArgumentListWrapping:AppStateReducerTest.kt$AppStateReducerTest$("/roms/dc/game.chd", "Game", "dreamcast", "Sega Dreamcast", direction = NavigationDirection.Up)</ID>
-    <ID>ArgumentListWrapping:AppStateReducerTest.kt$AppStateReducerTest$("/roms/dc/game.chd", "Game", "dreamcast", "Sega Dreamcast", navigationDirection = NavigationDirection.Up)</ID>
-    <ID>ArgumentListWrapping:AppStateReducerTest.kt$AppStateReducerTest$("dreamcast", "Sega Dreamcast", "/roms/dreamcast", direction = NavigationDirection.Right)</ID>
-    <ID>ArgumentListWrapping:AppStateReducerTest.kt$AppStateReducerTest$("dreamcast", "Sega Dreamcast", "/roms/dreamcast", navigationDirection = NavigationDirection.Right)</ID>
-    <ID>ArgumentListWrapping:BuildDrawerItemsTest.kt$BuildDrawerItemsTest$(DrawerItem.App(appB), DrawerItem.Folder(folder, listOf(appA)))</ID>
-    <ID>ArgumentListWrapping:BuildDrawerItemsTest.kt$BuildDrawerItemsTest$(appA)</ID>
-    <ID>ArgumentListWrapping:BuildDrawerItemsTest.kt$BuildDrawerItemsTest$(appA.packageName, "com.example.gone")</ID>
-    <ID>ArgumentListWrapping:BuildDrawerItemsTest.kt$BuildDrawerItemsTest$(appA.packageName, appB.packageName)</ID>
-    <ID>ArgumentListWrapping:BuildDrawerItemsTest.kt$BuildDrawerItemsTest$(appB)</ID>
-    <ID>ArgumentListWrapping:BuildDrawerItemsTest.kt$BuildDrawerItemsTest$(folder, listOf(appA))</ID>
-    <ID>ArgumentListWrapping:BuildDrawerItemsTest.kt$BuildDrawerItemsTest$(id = "folder-1", name = "Group", memberPackageNames = setOf(appA.packageName, "com.example.gone"))</ID>
-    <ID>ArgumentListWrapping:BuildDrawerItemsTest.kt$BuildDrawerItemsTest$(id = "folder-1", name = "Group", memberPackageNames = setOf(appA.packageName, appB.packageName))</ID>
-    <ID>ArgumentListWrapping:BuildDrawerItemsTest.kt$BuildDrawerItemsTest$(listOf(DrawerItem.App(appB), DrawerItem.Folder(folder, listOf(appA))).sortedBy { it.label }, result)</ID>
-    <ID>ArgumentListWrapping:EditWidgetsOverlay.kt$(0f, y)</ID>
-    <ID>ArgumentListWrapping:EditWidgetsOverlay.kt$(8.dp)</ID>
-    <ID>ArgumentListWrapping:EditWidgetsOverlay.kt$(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.6f), RoundedCornerShape(8.dp))</ID>
-    <ID>ArgumentListWrapping:EditWidgetsOverlay.kt$(alpha = 0.6f)</ID>
-    <ID>ArgumentListWrapping:EditWidgetsOverlay.kt$(color = gridLineColor, start = Offset(0f, y), end = Offset(size.width, y), strokeWidth = 2f)</ID>
-    <ID>ArgumentListWrapping:EditWidgetsOverlay.kt$(color = gridLineColor, start = Offset(x, 0f), end = Offset(x, size.height), strokeWidth = 2f)</ID>
-    <ID>ArgumentListWrapping:EditWidgetsOverlay.kt$(size.width, y)</ID>
-    <ID>ArgumentListWrapping:EditWidgetsOverlay.kt$(x, 0f)</ID>
-    <ID>ArgumentListWrapping:EditWidgetsOverlay.kt$(x, size.height)</ID>
-    <ID>ArgumentListWrapping:EditWidgetsViewModelTest.kt$EditWidgetsViewModelTest$(ScaleMode.Fit)</ID>
-    <ID>ArgumentListWrapping:EditWidgetsViewModelTest.kt$EditWidgetsViewModelTest$(StateGroup.System, listOf(placedWidget(id = "widget-a", zIndex = 0), placedWidget(id = "widget-b", zIndex = 1)))</ID>
-    <ID>ArgumentListWrapping:EditWidgetsViewModelTest.kt$EditWidgetsViewModelTest$(StateGroup.System, listOf(placedWidget(id = "widget-a", zIndex = 0, gridColumn = 1, gridRow = 1)))</ID>
-    <ID>ArgumentListWrapping:EditWidgetsViewModelTest.kt$EditWidgetsViewModelTest$(id = "existing-a", zIndex = 0)</ID>
-    <ID>ArgumentListWrapping:EditWidgetsViewModelTest.kt$EditWidgetsViewModelTest$(id = "existing-b", zIndex = 3)</ID>
-    <ID>ArgumentListWrapping:EditWidgetsViewModelTest.kt$EditWidgetsViewModelTest$(id = "widget-a", gridColumn = 5, gridRow = 0, columnSpan = 5, rowSpan = 10, zIndex = 0)</ID>
-    <ID>ArgumentListWrapping:EditWidgetsViewModelTest.kt$EditWidgetsViewModelTest$(id = "widget-a", zIndex = 0)</ID>
-    <ID>ArgumentListWrapping:EditWidgetsViewModelTest.kt$EditWidgetsViewModelTest$(id = "widget-a", zIndex = 0, gridColumn = 1, gridRow = 1)</ID>
-    <ID>ArgumentListWrapping:EditWidgetsViewModelTest.kt$EditWidgetsViewModelTest$(id = "widget-a", zIndex = 0, widgetType = WidgetType.SystemLogo(ScaleMode.Fit))</ID>
-    <ID>ArgumentListWrapping:EditWidgetsViewModelTest.kt$EditWidgetsViewModelTest$(id = "widget-b", zIndex = 1)</ID>
-    <ID>ArgumentListWrapping:EditWidgetsViewModelTest.kt$EditWidgetsViewModelTest$(placedWidget(id = "existing-a", zIndex = 0), placedWidget(id = "existing-b", zIndex = 3))</ID>
-    <ID>ArgumentListWrapping:EditWidgetsViewModelTest.kt$EditWidgetsViewModelTest$(placedWidget(id = "widget-a", gridColumn = 5, gridRow = 0, columnSpan = 5, rowSpan = 10, zIndex = 0))</ID>
-    <ID>ArgumentListWrapping:EditWidgetsViewModelTest.kt$EditWidgetsViewModelTest$(placedWidget(id = "widget-a", zIndex = 0), placedWidget(id = "widget-b", zIndex = 1))</ID>
-    <ID>ArgumentListWrapping:EditWidgetsViewModelTest.kt$EditWidgetsViewModelTest$(placedWidget(id = "widget-a", zIndex = 0, gridColumn = 1, gridRow = 1))</ID>
-    <ID>ArgumentListWrapping:EditWidgetsViewModelTest.kt$EditWidgetsViewModelTest$(placedWidget(id = "widget-a", zIndex = 0, widgetType = WidgetType.SystemLogo(ScaleMode.Fit)))</ID>
-    <ID>ArgumentListWrapping:EsdeSettingsParser.kt$EsdeSettingsParser$("""&lt;bool\s+name="${Regex.escape(settingName)}"\s+value="([^"]*)"\s*/&gt;""")</ID>
-    <ID>ArgumentListWrapping:EsdeSettingsParser.kt$EsdeSettingsParser$("""&lt;string\s+name="${Regex.escape(settingName)}"\s+value="([^"]*)"\s*/&gt;""")</ID>
-    <ID>ArgumentListWrapping:EsdeSettingsParser.kt$EsdeSettingsParser$(settingName)</ID>
-    <ID>ArgumentListWrapping:FileGameMediaRepository.kt$FileGameMediaRepository$(type, systemShortName, baseRelativePath)</ID>
-    <ID>ArgumentListWrapping:FindLegacyScriptFilesUseCase.kt$FindLegacyScriptFilesUseCase$(esdeRootPath)</ID>
-    <ID>ArgumentListWrapping:GameManualViewModel.kt$GameManualViewModel$(MediaType.Manuals)</ID>
-    <ID>ArgumentListWrapping:GameManualViewModel.kt$GameManualViewModel$(it.systemShortName, it.romPath)</ID>
-    <ID>ArgumentListWrapping:LongPressSettingsMenu.kt$(onEditWidgetsClick = onEditWidgetsClick)</ID>
-    <ID>ArgumentListWrapping:LongPressSettingsMenu.kt$(slideOutHorizontally(tween(220)) { -slideDistance(it) } + fadeOut(tween(150)))</ID>
-    <ID>ArgumentListWrapping:MainActivity.kt$MainActivity$(appContainer)</ID>
-    <ID>ArgumentListWrapping:MainActivity.kt$MainActivity$(factory = AppDockViewModelFactory(appContainer))</ID>
-    <ID>ArgumentListWrapping:MainActivity.kt$MainActivity$(factory = AppDrawerViewModelFactory(appContainer))</ID>
-    <ID>ArgumentListWrapping:MainActivity.kt$MainActivity$(factory = GameManualViewModelFactory(appContainer))</ID>
-    <ID>ArgumentListWrapping:MainActivity.kt$MainActivity$(factory = ManageAppsViewModelFactory(appContainer))</ID>
-    <ID>ArgumentListWrapping:MainActivity.kt$MainActivity$(factory = SettingsViewModelFactory(appContainer))</ID>
-    <ID>ArgumentListWrapping:MainActivity.kt$MainActivity$(factory = WidgetsViewModelFactory(appContainer))</ID>
-    <ID>ArgumentListWrapping:MainActivity.kt$MainActivity$(imageVector = Icons.Filled.MusicNote, contentDescription = "Music controls")</ID>
-    <ID>ArgumentListWrapping:MainActivity.kt$MainActivity$(videoPlaybackEnabled, videoPath, isBrowsingGame, mainScreenActive, isActivityVisible)</ID>
-    <ID>ArgumentListWrapping:MainActivity.kt$MainActivity$(visible = isBlanked &amp;&amp; mainScreenActive, enter = fadeIn(), exit = fadeOut())</ID>
-    <ID>ArgumentListWrapping:MainActivity.kt$MainActivity$(visible = isDimmed &amp;&amp; mainScreenActive, enter = fadeIn(), exit = fadeOut())</ID>
-    <ID>ArgumentListWrapping:MainActivity.kt$MainActivity$(visible = musicControlsRevealed, enter = fadeIn(), exit = fadeOut())</ID>
-    <ID>ArgumentListWrapping:MainActivity.kt$MainActivity$(visible = showGameManual &amp;&amp; mainScreenActive, enter = fadeIn(), exit = fadeOut())</ID>
-    <ID>ArgumentListWrapping:MusicPlaybackCoordinatorTest.kt$MusicPlaybackCoordinatorTest$("a" to MusicPoolContents(MusicPool.PerSystem("a"), listOf(trackA1, trackA2)))</ID>
-    <ID>ArgumentListWrapping:MusicPlaybackCoordinatorTest.kt$MusicPlaybackCoordinatorTest$(logRepository, ObserveAppStateUseCase(logRepository, scope))</ID>
-    <ID>ArgumentListWrapping:MusicPlaybackCoordinatorTest.kt$MusicPlaybackCoordinatorTest$(logRepository, scope)</ID>
-    <ID>ArgumentListWrapping:NavigationDirectionTrackerTest.kt$NavigationDirectionTrackerTest$("Scripting::fireEvent(): game-select \"/roms/game.zip\" \"Buggy Run\" \"mastersystem\" \"Sega Master System\"")</ID>
-    <ID>ArgumentListWrapping:NavigationDirectionTrackerTest.kt$NavigationDirectionTrackerTest$("Scripting::fireEvent(): system-select \"mastersystem\" \"Sega Master System\" \"/roms/mastersystem\" \"\"")</ID>
-    <ID>ArgumentListWrapping:OnboardingScreen.kt$("This folder doesn't exist. Choose the correct folder.")</ID>
-    <ID>ArgumentListWrapping:OnboardingScreen.kt$(slideOutHorizontally(tween(220)) { -slideDistance(it) } + fadeOut(tween(150)))</ID>
-    <ID>ArgumentListWrapping:OnboardingScreen.kt$(slideOutHorizontally(tween(220)) { slideDistance(it) } + fadeOut(tween(150)))</ID>
-    <ID>ArgumentListWrapping:OnboardingViewModelTest.kt$OnboardingViewModelTest$(LogFolderValidation.FolderFound(settingsFileFound = true), viewModel.uiState.value.logFolderValidation)</ID>
-    <ID>ArgumentListWrapping:OnboardingViewModelTest.kt$OnboardingViewModelTest$(onboardingRepository = onboardingRepo, installationRepository = installationRepo)</ID>
-    <ID>ArgumentListWrapping:OnboardingViewModelTest.kt$OnboardingViewModelTest$(settingsFileFound = true)</ID>
-    <ID>ArgumentListWrapping:ReactiveEsdeLogRepositoryTest.kt$ReactiveEsdeLogRepositoryTest$(exists = folder == "/storage/emulated/0/ES-DE")</ID>
-    <ID>ArgumentListWrapping:ReadEsdeMediaDirectoryUseCase.kt$ReadEsdeMediaDirectoryUseCase$(esdeRootPath)</ID>
-    <ID>ArgumentListWrapping:SetOtherScreenLaunchAppsUseCase.kt$SetOtherScreenLaunchAppsUseCase$(packageNames)</ID>
-    <ID>ArgumentListWrapping:SettingsViewModelTest.kt$SettingsViewModelTest$(onboardingRepository)</ID>
-    <ID>ArgumentListWrapping:UISettingsContent.kt$(ScreenBehavior.Nothing, ScreenBehavior.Dim, ScreenBehavior.Black, ScreenBehavior.GameManual)</ID>
-    <ID>ArgumentListWrapping:WidgetColorConfig.kt$(text = "Transparency: ${(current.alpha * 100).roundToInt()}%", style = MaterialTheme.typography.titleSmall)</ID>
-    <ID>ArgumentListWrapping:WidgetContent.kt$(fallbackBackgroundAssetPath, scaleMode, isTransparentOverlay = false, isAsset = true, effects = effects)</ID>
-    <ID>ArgumentListWrapping:WidgetContentResolverTest.kt$WidgetContentResolverTest$("/media/fanart.png", ScaleMode.Fill, isTransparentOverlay = false, isAsset = false)</ID>
-    <ID>ArgumentListWrapping:WidgetContentResolverTest.kt$WidgetContentResolverTest$("/media/marquee.png", ScaleMode.Fit, isTransparentOverlay = true, isAsset = false)</ID>
-    <ID>ArgumentListWrapping:WidgetContentResolverTest.kt$WidgetContentResolverTest$("/storage/emulated/0/Pictures/cover.jpg", ScaleMode.Fill, isTransparentOverlay = false, isAsset = false)</ID>
-    <ID>ArgumentListWrapping:WidgetContentResolverTest.kt$WidgetContentResolverTest$("fallback.webp", ScaleMode.Fill, isTransparentOverlay = false, isAsset = true)</ID>
-    <ID>ArgumentListWrapping:WidgetContentResolverTest.kt$WidgetContentResolverTest$("file:///android_asset/system_logos/dreamcast.svg", ScaleMode.Fit)</ID>
-    <ID>ArgumentListWrapping:WidgetContentResolverTest.kt$WidgetContentResolverTest$(WidgetContent.Image("/media/fanart.png", ScaleMode.Fill, isTransparentOverlay = false, isAsset = false), content)</ID>
-    <ID>ArgumentListWrapping:WidgetContentResolverTest.kt$WidgetContentResolverTest$(WidgetContent.Image("/media/marquee.png", ScaleMode.Fit, isTransparentOverlay = true, isAsset = false), content)</ID>
-    <ID>ArgumentListWrapping:WidgetContentResolverTest.kt$WidgetContentResolverTest$(WidgetContent.Image("fallback.webp", ScaleMode.Fill, isTransparentOverlay = false, isAsset = true), content)</ID>
-    <ID>ArgumentListWrapping:WidgetContentResolverTest.kt$WidgetContentResolverTest$(WidgetContent.SystemLogoAsset("file:///android_asset/system_logos/dreamcast.svg", ScaleMode.Fit), content)</ID>
-    <ID>ArgumentListWrapping:WidgetContentResolverTest.kt$WidgetContentResolverTest$(path = "/storage/emulated/0/Pictures/cover.jpg", scaleMode = ScaleMode.Fill)</ID>
-    <ID>ArgumentListWrapping:WidgetImageConfigControls.kt$(text = "Blur: ${(current.blurAmount * 100).roundToInt()}%", style = MaterialTheme.typography.titleSmall)</ID>
-    <ID>ArgumentListWrapping:WidgetImageConfigControls.kt$(text = "Darken: ${(current.darkenAmount * 100).roundToInt()}%", style = MaterialTheme.typography.titleSmall)</ID>
-    <ID>ArgumentListWrapping:WidgetImageTransitionEligibilityTest.kt$WidgetImageTransitionEligibilityTest$("p", ScaleMode.Fill, imageTransitionMode = ImageTransitionMode.Fade)</ID>
-    <ID>ArgumentListWrapping:WidgetImageTransitionEligibilityTest.kt$WidgetImageTransitionEligibilityTest$(MediaType.Covers, ScaleMode.Fill, imageTransitionMode = ImageTransitionMode.Fade)</ID>
-    <ID>ArgumentListWrapping:WidgetImageTransitionEligibilityTest.kt$WidgetImageTransitionEligibilityTest$(MediaType.FanArt, ScaleMode.Fill, imageTransitionMode = ImageTransitionMode.Fade)</ID>
-    <ID>ArgumentListWrapping:WidgetImageTransitionEligibilityTest.kt$WidgetImageTransitionEligibilityTest$(MediaType.Screenshots, ScaleMode.Fill, imageTransitionMode = ImageTransitionMode.Fade)</ID>
-    <ID>ArgumentListWrapping:WidgetImageTransitionEligibilityTest.kt$WidgetImageTransitionEligibilityTest$(ScaleMode.Fill, logoTransitionMode = LogoTransitionMode.Slide, glintEnabled = true)</ID>
-    <ID>ArgumentListWrapping:WidgetLayoutMapping.kt$(fontSizeSp, textColorArgb, backgroundColorArgb, backgroundAlpha)</ID>
-    <ID>ArgumentListWrapping:WidgetLayoutMapping.kt$(id, widgetType.toDomain(), gridColumn, gridRow, columnSpan, rowSpan, zIndex)</ID>
-    <ID>ArgumentListWrapping:WidgetLayoutMapping.kt$(id, widgetType.toDto(), gridColumn, gridRow, columnSpan, rowSpan, zIndex)</ID>
-    <ID>ArgumentListWrapping:WidgetLayoutMapping.kt$(scaleMode.toDto(), effects.blurAmount, effects.darkenAmount, logoTransitionMode.toDto(), glintEnabled)</ID>
-    <ID>ArgumentListWrapping:WidgetLayoutMappingTest.kt$WidgetLayoutMappingTest$(ScaleMode.Fit, logoTransitionMode = LogoTransitionMode.Slide, glintEnabled = true)</ID>
-    <ID>ArgumentListWrapping:WidgetTypeDialogs.kt$(current = widgetType.logoTransitionMode)</ID>
-    <ID>ArgumentListWrapping:WidgetTypeDialogs.kt$(enabled = widgetType.glintEnabled)</ID>
-    <ID>ArgumentListWrapping:WidgetTypeDialogs.kt$(enabled = widgetType.panZoomEnabled)</ID>
-    <ID>ArgumentListWrapping:WidgetTypeDialogs.kt$(glintEnabled = it)</ID>
-    <ID>ArgumentListWrapping:WidgetTypeDialogs.kt$(logoTransitionMode = it)</ID>
-    <ID>ArgumentListWrapping:WidgetTypeDialogs.kt$(panZoomEnabled = it)</ID>
-    <ID>ArgumentListWrapping:WidgetTypeDialogs.kt$(widgetType.copy(glintEnabled = it))</ID>
-    <ID>ArgumentListWrapping:WidgetTypeDialogs.kt$(widgetType.copy(logoTransitionMode = it))</ID>
-    <ID>ArgumentListWrapping:WidgetTypeDialogs.kt$(widgetType.copy(panZoomEnabled = it))</ID>
-    <ID>ArgumentListWrapping:WidgetsViewModel.kt$WidgetsViewModel$(it)</ID>
-    <ID>ArgumentListWrapping:WidgetsViewModel.kt$WidgetsViewModel$(systemLogoAssetName(it))</ID>
-    <ID>ArgumentListWrapping:WidgetsViewModel.kt$WidgetsViewModel$(widgets, identity)</ID>
-    <ID>ArgumentListWrapping:WidgetsViewModel.kt$WidgetsViewModel$(widgets, resolveContent(widgets, identity), identity.navigationDirection)</ID>
     <ID>CyclomaticComplexMethod:AppDrawer.kt$@OptIn(ExperimentalSharedTransitionApi::class) @Composable fun AppDrawer( viewModel: AppDrawerViewModel, onAppLaunched: () -&gt; Unit, onFolderOpenChanged: (Boolean) -&gt; Unit = {}, isDrawerOpen: Boolean = true, onOpenSettings: () -&gt; Unit = {}, modifier: Modifier = Modifier, )</ID>
     <ID>CyclomaticComplexMethod:AppStateReducer.kt$AppStateReducer$fun reduce( current: AppState, event: EsdeEvent, ): AppState</ID>
     <ID>CyclomaticComplexMethod:EditWidgetsOverlay.kt$@Composable fun EditWidgetsOverlay( viewModel: EditWidgetsViewModel, initialCanvas: StateGroup, onDone: () -&gt; Unit, modifier: Modifier = Modifier, )</ID>
@@ -169,6 +34,7 @@
     <ID>Indentation:DefaultWidgetLayouts.kt$ </ID>
     <ID>Indentation:EditWidgetsOverlay.kt$ </ID>
     <ID>Indentation:EditWidgetsViewModel.kt$EditWidgetsViewModel$ </ID>
+    <ID>Indentation:FileEsdeInstallationRepository.kt$FileEsdeInstallationRepository$ </ID>
     <ID>Indentation:FolderContentsPopup.kt$ </ID>
     <ID>Indentation:GameManualScreen.kt$ </ID>
     <ID>Indentation:LongPressSettingsMenu.kt$ </ID>
@@ -176,11 +42,13 @@
     <ID>Indentation:MainScreen.kt$ </ID>
     <ID>Indentation:ManageAppsScreen.kt$ </ID>
     <ID>Indentation:ManageAppsViewModelTest.kt$ManageAppsViewModelTest$ </ID>
+    <ID>Indentation:MusicPlaybackCoordinatorTest.kt$MusicPlaybackCoordinatorTest$ </ID>
     <ID>Indentation:OnboardingScreen.kt$ </ID>
     <ID>Indentation:OtherSettingsContent.kt$ </ID>
     <ID>Indentation:PanZoomImage.kt$ </ID>
     <ID>Indentation:ScrollingText.kt$ </ID>
     <ID>Indentation:SettingsShared.kt$ </ID>
+    <ID>Indentation:SettingsViewModelTest.kt$SettingsViewModelTest$ </ID>
     <ID>Indentation:SetupSettingsContent.kt$ </ID>
     <ID>Indentation:SoundSettingsContent.kt$ </ID>
     <ID>Indentation:ThorSettingsContent.kt$ </ID>
@@ -189,6 +57,7 @@
     <ID>Indentation:VideoPlaybackSettingsContent.kt$ </ID>
     <ID>Indentation:WidgetCanvas.kt$ </ID>
     <ID>Indentation:WidgetColorConfig.kt$ </ID>
+    <ID>Indentation:WidgetContentResolverTest.kt$WidgetContentResolverTest$ </ID>
     <ID>Indentation:WidgetResizeGeometry.kt$ </ID>
     <ID>Indentation:WidgetTextConfigControls.kt$ </ID>
     <ID>Indentation:WidgetTypeDialogs.kt$ </ID>
@@ -217,9 +86,11 @@
     <ID>LongMethod:SettingsViewModelTest.kt$SettingsViewModelTest$private fun buildViewModel( onboardingRepository: FakeOnboardingRepository = FakeOnboardingRepository(), appDrawerSettingsRepository: FakeAppDrawerSettingsRepository = FakeAppDrawerSettingsRepository(), dockSettingsRepository: FakeDockSettingsRepository = FakeDockSettingsRepository(), installedAppsRepository: FakeInstalledAppsRepository = FakeInstalledAppsRepository(), thorSettingsRepository: FakeThorSettingsRepository = FakeThorSettingsRepository(), ): Pair&lt;SettingsViewModel, FakeAppDrawerSettingsRepository&gt;</ID>
     <ID>LongMethod:WidgetCanvas.kt$@Composable internal fun WidgetContentView( content: WidgetContent, widgetType: WidgetType, navigationDirection: NavigationDirection? = null, modifier: Modifier = Modifier, textUserScrollEnabled: Boolean = true, )</ID>
     <ID>LongMethod:WidgetContentResolver.kt$WidgetContentResolver$fun resolve( widgetType: WidgetType, systemLogoAssetPath: () -&gt; String?, customSystemLogoLookup: () -&gt; String?, customSystemImageLookup: () -&gt; String?, systemMediaLookup: (MediaType) -&gt; String?, gameMediaLookup: (MediaType) -&gt; String?, gameDescriptionLookup: () -&gt; String?, gameRatingLookup: () -&gt; Float? = { null }, fallbackBackgroundAssetPath: String?, systemNameLookup: () -&gt; String? = { null }, gameNameLookup: () -&gt; String? = { null }, ): WidgetContent</ID>
+    <ID>LongMethod:WidgetLayoutMapping.kt$private fun WidgetType.toDto(): WidgetTypeDto</ID>
     <ID>LongMethod:WidgetResizeGeometry.kt$@Composable internal fun ResizeHandle( edge: ResizeEdge, widget: PlacedWidget, grid: GridDimensions, cellWidth: Dp, cellHeight: Dp, onResize: (widgetId: String, gridColumn: Int, gridRow: Int, columnSpan: Int, rowSpan: Int) -&gt; Unit, onDragStateChanged: (Boolean) -&gt; Unit, onDragEnd: () -&gt; Unit, modifier: Modifier = Modifier, )</ID>
     <ID>LongMethod:WidgetTextConfigControls.kt$@Composable internal fun GameDescriptionConfig( current: WidgetType.GameDescription, onChange: (WidgetType.GameDescription) -&gt; Unit, )</ID>
     <ID>LongMethod:WidgetTypeDialogs.kt$@Composable internal fun ConfigureWidgetDialog( widgetType: WidgetType, onChange: (WidgetType) -&gt; Unit, onDismiss: () -&gt; Unit, )</ID>
+    <ID>LongMethod:WidgetsViewModel.kt$WidgetsViewModel$private suspend fun resolveContent( widgets: List&lt;PlacedWidget&gt;, identity: ContentIdentity, ): Map&lt;String, WidgetContent&gt;</ID>
     <ID>LongParameterList:AnimatedLogoImage.kt$( model: Any?, contentDescription: String?, contentScale: ContentScale, mode: LogoTransitionMode, direction: NavigationDirection? = null, glintEnabled: Boolean = false, modifier: Modifier = Modifier, durationMillis: Int = 500, )</ID>
     <ID>LongParameterList:AppDock.kt$( app: InstalledApp, iconDp: Dp, isAppDrawerShortcut: Boolean, isOtherScreenPreferred: Boolean, isLeftmost: Boolean, isRightmost: Boolean, onClick: () -&gt; Unit, onDoubleClick: () -&gt; Unit, onLaunchThisScreen: () -&gt; Unit, onLaunchOtherScreen: () -&gt; Unit, onAppInfo: () -&gt; Unit, onMoveLeft: () -&gt; Unit, onMoveRight: () -&gt; Unit, onRemove: () -&gt; Unit, )</ID>
     <ID>LongParameterList:AppDock.kt$( expanded: Boolean, appLabel: String, isAppDrawerShortcut: Boolean, isOtherScreenPreferred: Boolean, isLeftmost: Boolean, isRightmost: Boolean, onDismiss: () -&gt; Unit, onLaunchThisScreen: () -&gt; Unit, onLaunchOtherScreen: () -&gt; Unit, onAppInfo: () -&gt; Unit, onMoveLeft: () -&gt; Unit, onMoveRight: () -&gt; Unit, onRemove: () -&gt; Unit, )</ID>
@@ -298,222 +169,13 @@
     <ID>MagicNumber:WidgetColorConfig.kt$0xFFFFFFFFL</ID>
     <ID>MagicNumber:WidgetColorConfig.kt$16</ID>
     <ID>MagicNumber:WidgetColorConfig.kt$6</ID>
-    <ID>MaxLineLength:AppDock.kt$AppLauncher.launch(context, app.packageName, displayId = SecondaryDisplayResolver.secondaryDisplayId(context))</ID>
-    <ID>MaxLineLength:AppDock.kt$if (MaterialTheme.colorScheme.surface.luminance() &lt; 0.5f) Color.White.copy(alpha = 0.3f) else Color.Black.copy(alpha = 0.3f)</ID>
-    <ID>MaxLineLength:AppDock.kt$private</ID>
-    <ID>MaxLineLength:AppDockViewModel.kt$AppDockViewModel$.</ID>
-    <ID>MaxLineLength:AppDockViewModel.kt$AppDockViewModel$}</ID>
-    <ID>MaxLineLength:AppDockViewModelTest.kt$AppDockViewModelTest$val repository = FakeDockSettingsRepository(initialDockApps = listOf("com.example.a", "com.example.b", "com.example.c"))</ID>
-    <ID>MaxLineLength:AppDrawer.kt$internal</ID>
-    <ID>MaxLineLength:AppDrawerViewModel.kt$AppDrawerViewModel$val newFolder = AppFolder(id = UUID.randomUUID().toString(), name = name, memberPackageNames = setOf(packageName))</ID>
-    <ID>MaxLineLength:AppDrawerViewModelTest.kt$AppDrawerViewModelTest$listOf(DrawerItem.App(allApps[1]), DrawerItem.App(allApps[2]), DrawerItem.Folder(folder, listOf(allApps[0])))</ID>
-    <ID>MaxLineLength:AppDrawerViewModelTest.kt$AppDrawerViewModelTest$listOf(DrawerItem.Folder(folder, listOf(allApps[0])), DrawerItem.App(allApps[1]), DrawerItem.App(allApps[2]))</ID>
-    <ID>MaxLineLength:AppDrawerViewModelTest.kt$AppDrawerViewModelTest$val folder = AppFolder(id = "folder-1", name = "Group", memberPackageNames = setOf("com.example.a", "com.example.b"))</ID>
-    <ID>MaxLineLength:AppDrawerViewModelTest.kt$AppDrawerViewModelTest$val settingsRepository = FakeAppDrawerSettingsRepository(initialOtherScreenLaunchApps = setOf("com.example.a"))</ID>
-    <ID>MaxLineLength:AppStateReducerTest.kt$AppStateReducerTest$AppState.BrowsingGame("/roms/dc/game.chd", "Game", "dreamcast", "Sega Dreamcast", navigationDirection = NavigationDirection.Up)</ID>
-    <ID>MaxLineLength:AppStateReducerTest.kt$AppStateReducerTest$AppState.BrowsingSystem("dreamcast", "Sega Dreamcast", "/roms/dreamcast", navigationDirection = NavigationDirection.Right)</ID>
-    <ID>MaxLineLength:AppStateReducerTest.kt$AppStateReducerTest$fun</ID>
-    <ID>MaxLineLength:AppStateReducerTest.kt$AppStateReducerTest$val event = EsdeEvent.GameSelect("/roms/dc/game.chd", "Game", "dreamcast", "Sega Dreamcast", direction = NavigationDirection.Up)</ID>
-    <ID>MaxLineLength:AppStateReducerTest.kt$AppStateReducerTest$val event = EsdeEvent.SystemSelect("dreamcast", "Sega Dreamcast", "/roms/dreamcast", direction = NavigationDirection.Right)</ID>
-    <ID>MaxLineLength:AutoCollectionAssets.kt$fun systemLogoAssetName(systemShortName: String): String</ID>
-    <ID>MaxLineLength:BuildDrawerItemsTest.kt$BuildDrawerItemsTest$assertEquals(listOf(DrawerItem.App(appB), DrawerItem.Folder(folder, listOf(appA))).sortedBy { it.label }, result)</ID>
-    <ID>MaxLineLength:BuildDrawerItemsTest.kt$BuildDrawerItemsTest$val folder = AppFolder(id = "folder-1", name = "Group", memberPackageNames = setOf(appA.packageName, "com.example.gone"))</ID>
-    <ID>MaxLineLength:BuildDrawerItemsTest.kt$BuildDrawerItemsTest$val folder = AppFolder(id = "folder-1", name = "Group", memberPackageNames = setOf(appA.packageName, appB.packageName))</ID>
-    <ID>MaxLineLength:EditWidgetsOverlay.kt$Modifier.background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.6f), RoundedCornerShape(8.dp))</ID>
-    <ID>MaxLineLength:EditWidgetsOverlay.kt$drawLine(color = gridLineColor, start = Offset(0f, y), end = Offset(size.width, y), strokeWidth = 2f)</ID>
-    <ID>MaxLineLength:EditWidgetsOverlay.kt$drawLine(color = gridLineColor, start = Offset(x, 0f), end = Offset(x, size.height), strokeWidth = 2f)</ID>
-    <ID>MaxLineLength:EditWidgetsViewModel.kt$EditWidgetsViewModel$randomSystemMediaCache.getOrPut(shortName to mediaType) { resolveRandomSystemMedia(shortName, mediaType) }</ID>
-    <ID>MaxLineLength:EditWidgetsViewModelTest.kt$EditWidgetsViewModelTest$listOf(placedWidget(id = "existing-a", zIndex = 0), placedWidget(id = "existing-b", zIndex = 3))</ID>
-    <ID>MaxLineLength:EditWidgetsViewModelTest.kt$EditWidgetsViewModelTest$listOf(placedWidget(id = "widget-a", gridColumn = 5, gridRow = 0, columnSpan = 5, rowSpan = 10, zIndex = 0))</ID>
-    <ID>MaxLineLength:EditWidgetsViewModelTest.kt$EditWidgetsViewModelTest$listOf(placedWidget(id = "widget-a", zIndex = 0, widgetType = WidgetType.SystemLogo(ScaleMode.Fit)))</ID>
-    <ID>MaxLineLength:EditWidgetsViewModelTest.kt$EditWidgetsViewModelTest$seed(StateGroup.System, listOf(placedWidget(id = "widget-a", zIndex = 0), placedWidget(id = "widget-b", zIndex = 1)))</ID>
-    <ID>MaxLineLength:EditWidgetsViewModelTest.kt$EditWidgetsViewModelTest$seed(StateGroup.System, listOf(placedWidget(id = "widget-a", zIndex = 0, gridColumn = 1, gridRow = 1)))</ID>
-    <ID>MaxLineLength:EsdeEventParserTest.kt$EsdeEventParserTest$"\"/storage/E2AB-E84A/ROMs/gba/Mega\\ Man\\ Battle\\ Network\\ 3\\ -\\ White\\ Version\\ \\(USA\\).zip\" "</ID>
-    <ID>MaxLineLength:EsdeLogFileRepositoryTest.kt$EsdeLogFileRepositoryTest$"Jul 28 15:16:07 Debug: Scripting::fireEvent(): system-select \"psx\" \"Sony PlayStation\" \"/storage/E2AB-E84A/ROMs/psx\" \"\"\n"</ID>
     <ID>MaxLineLength:EsdeLogFileRepositoryTest.kt$EsdeLogFileRepositoryTest$fun</ID>
-    <ID>MaxLineLength:EsdeSettingsParser.kt$EsdeSettingsParser$private fun boolRegexFor(settingName: String)</ID>
-    <ID>MaxLineLength:EsdeSettingsParser.kt$EsdeSettingsParser$private fun stringRegexFor(settingName: String)</ID>
-    <ID>MaxLineLength:FileAppDrawerSettingsRepository.kt$FileAppDrawerSettingsRepository$override fun observeHiddenApps(): Flow&lt;Set&lt;String&gt;&gt;</ID>
-    <ID>MaxLineLength:FileDockSettingsRepository.kt$FileDockSettingsRepository$override fun observeDockEnabled(): Flow&lt;Boolean&gt;</ID>
-    <ID>MaxLineLength:FileDockSettingsRepository.kt$FileDockSettingsRepository$override fun observeDockMaxApps(): Flow&lt;Int&gt;</ID>
-    <ID>MaxLineLength:FileEsdeInstallationRepository.kt$FileEsdeInstallationRepository$customEventScriptsBrowsing = EsdeSettingsParser.findBoolValue(xml, "CustomEventScriptsBrowsing") ?: false</ID>
-    <ID>MaxLineLength:FileGameMediaRepository.kt$FileGameMediaRepository$.</ID>
-    <ID>MaxLineLength:FileLastKnownContextRepository.kt$FileLastKnownContextRepository$override fun observeLastSystemShortName(): Flow&lt;String?&gt;</ID>
-    <ID>MaxLineLength:FileOnboardingRepository.kt$FileOnboardingRepository$override fun observeCustomLogosFolderPath(): Flow&lt;String?&gt;</ID>
-    <ID>MaxLineLength:FileOnboardingRepository.kt$FileOnboardingRepository$override fun observeCustomMusicFolderPath(): Flow&lt;String?&gt;</ID>
-    <ID>MaxLineLength:FileOnboardingRepository.kt$FileOnboardingRepository$override fun observeLogFolderPath(): Flow&lt;String?&gt;</ID>
-    <ID>MaxLineLength:FileOnboardingRepository.kt$FileOnboardingRepository$override fun observeMediaFolderPath(): Flow&lt;String?&gt;</ID>
-    <ID>MaxLineLength:FileOnboardingRepository.kt$FileOnboardingRepository$override fun observeMusicEnabled(): Flow&lt;Boolean&gt;</ID>
-    <ID>MaxLineLength:FileOnboardingRepository.kt$FileOnboardingRepository$override fun observeOnboardingComplete(): Flow&lt;Boolean&gt;</ID>
-    <ID>MaxLineLength:FileOnboardingRepository.kt$FileOnboardingRepository$override fun observeSettingsFabVisible(): Flow&lt;Boolean&gt;</ID>
-    <ID>MaxLineLength:FileOnboardingRepository.kt$FileOnboardingRepository$override fun observeVideoAudioEnabled(): Flow&lt;Boolean&gt;</ID>
-    <ID>MaxLineLength:FindLegacyScriptFilesUseCase.kt$FindLegacyScriptFilesUseCase$suspend operator fun invoke(esdeRootPath: String): List&lt;String&gt;</ID>
-    <ID>MaxLineLength:GameManualViewModel.kt$GameManualViewModel$.</ID>
-    <ID>MaxLineLength:LongPressSettingsMenu.kt$.</ID>
-    <ID>MaxLineLength:LongPressSettingsMenu.kt$SettingsCategory.Widgets -&gt; WidgetsSettingsContent(onEditWidgetsClick = onEditWidgetsClick)</ID>
-    <ID>MaxLineLength:LongPressSettingsMenu.kt$onCloseCompanionOnQuitEnabledChanged = settingsViewModel::onCloseCompanionOnQuitEnabledChanged</ID>
-    <ID>MaxLineLength:LongPressSettingsMenu.kt$onCustomSystemImagesFolderCleared = settingsViewModel::onCustomSystemImagesFolderCleared</ID>
-    <ID>MaxLineLength:LongPressSettingsMenu.kt$onCustomSystemImagesFolderPicked = settingsViewModel::onCustomSystemImagesFolderPicked</ID>
-    <ID>MaxLineLength:LongPressSettingsMenu.kt$onGamePlayingDimPercentChanged = settingsViewModel::onGamePlayingDimPercentChanged</ID>
-    <ID>MaxLineLength:LongPressSettingsMenu.kt$onManageAppsClick = { page = MenuPage.ManageApps(fromCategory = targetPage.category) }</ID>
-    <ID>MaxLineLength:LongPressSettingsMenu.kt$onMusicPlayDuringScreensaverChanged = settingsViewModel::onMusicPlayDuringScreensaverChanged</ID>
-    <ID>MaxLineLength:LongPressSettingsMenu.kt$onMusicPlayWhileBrowsingGamesChanged = settingsViewModel::onMusicPlayWhileBrowsingGamesChanged</ID>
-    <ID>MaxLineLength:LongPressSettingsMenu.kt$onMusicPlayWhileBrowsingSystemsChanged = settingsViewModel::onMusicPlayWhileBrowsingSystemsChanged</ID>
-    <ID>MaxLineLength:LongPressSettingsMenu.kt$onScreensaverDimPercentChanged = settingsViewModel::onScreensaverDimPercentChanged</ID>
-    <ID>MaxLineLength:LongPressSettingsMenu.kt$onVideoPlaybackEnabledChanged = settingsViewModel::onVideoPlaybackEnabledChanged</ID>
-    <ID>MaxLineLength:MainActivity.kt$MainActivity$"mainScreenActive=$mainScreenActive visible=$isActivityVisible -&gt; show=$showVideoOverlay"</ID>
-    <ID>MaxLineLength:MainActivity.kt$MainActivity$AnimatedVisibility</ID>
-    <ID>MaxLineLength:MainActivity.kt$MainActivity$Icon(imageVector = Icons.Filled.MusicNote, contentDescription = "Music controls")</ID>
-    <ID>MaxLineLength:MainActivity.kt$MainActivity$LaunchedEffect</ID>
-    <ID>MaxLineLength:MainActivity.kt$MainActivity$val appDrawerViewModel: AppDrawerViewModel = viewModel(factory = AppDrawerViewModelFactory(appContainer))</ID>
-    <ID>MaxLineLength:MainActivity.kt$MainActivity$val dockViewModel: AppDockViewModel = viewModel(factory = AppDockViewModelFactory(appContainer))</ID>
-    <ID>MaxLineLength:MainActivity.kt$MainActivity$val gameManualViewModel: GameManualViewModel = viewModel(factory = GameManualViewModelFactory(appContainer))</ID>
-    <ID>MaxLineLength:MainActivity.kt$MainActivity$val isBrowsingGame = (connectionState as? EsdeConnectionState.Connected)?.appState is AppState.BrowsingGame</ID>
-    <ID>MaxLineLength:MainActivity.kt$MainActivity$val isPlayingGame = (connectionState as? EsdeConnectionState.Connected)?.appState is AppState.PlayingGame</ID>
-    <ID>MaxLineLength:MainActivity.kt$MainActivity$val manageAppsViewModel: ManageAppsViewModel = viewModel(factory = ManageAppsViewModelFactory(appContainer))</ID>
-    <ID>MaxLineLength:MainActivity.kt$MainActivity$val overlayMaxWidth = maxWidth - overlayStart - SETTINGS_BUTTON_RESERVED_WIDTH</ID>
-    <ID>MaxLineLength:MainActivity.kt$MainActivity$val overlayStart = CORNER_BUTTON_EDGE_PADDING + CORNER_BUTTON_SIZE + MUSIC_OVERLAY_GAP</ID>
-    <ID>MaxLineLength:MainActivity.kt$MainActivity$val settingsViewModel: SettingsViewModel = viewModel(factory = SettingsViewModelFactory(appContainer))</ID>
-    <ID>MaxLineLength:MainActivity.kt$MainActivity$val widgetsViewModel: WidgetsViewModel = viewModel(factory = WidgetsViewModelFactory(appContainer))</ID>
-    <ID>MaxLineLength:MusicControlsOverlay.kt$(0 until titleLayout.lineCount).maxOf { titleLayout.getLineRight(it) - titleLayout.getLineLeft(it) }.toDp()</ID>
-    <ID>MaxLineLength:MusicPlaybackCoordinatorTest.kt$MusicPlaybackCoordinatorTest$poolsByRequestedSystem = mapOf("a" to MusicPoolContents(MusicPool.PerSystem("a"), listOf(trackA1, trackA2)))</ID>
-    <ID>MaxLineLength:MusicPlaybackCoordinatorTest.kt$MusicPlaybackCoordinatorTest$val observeConnectionState = ObserveConnectionStateUseCase(logRepository, ObserveAppStateUseCase(logRepository, scope))</ID>
-    <ID>MaxLineLength:NavigationDirectionParser.kt$NavigationDirectionParser$fun</ID>
-    <ID>MaxLineLength:NavigationDirectionParserTest.kt$NavigationDirectionParserTest$val line = "Aug 02 13:31:31 Debug: Window::logInput(Xbox Wireless Controller): Button 12, isMappedTo=down, value=1"</ID>
-    <ID>MaxLineLength:NavigationDirectionParserTest.kt$NavigationDirectionParserTest$val line = "Aug 02 13:31:33 Debug: Window::logInput(Xbox Wireless Controller): Button 11, isMappedTo=up, value=0 "</ID>
-    <ID>MaxLineLength:NavigationDirectionParserTest.kt$NavigationDirectionParserTest$val line = "Aug 02 13:31:33 Debug: Window::logInput(Xbox Wireless Controller): Button 11, isMappedTo=up, value=0"</ID>
-    <ID>MaxLineLength:NavigationDirectionParserTest.kt$NavigationDirectionParserTest$val line = "Aug 02 13:31:33 Debug: Window::logInput(Xbox Wireless Controller): Button 11, isMappedTo=up, value=1"</ID>
-    <ID>MaxLineLength:NavigationDirectionParserTest.kt$NavigationDirectionParserTest$val line = "Aug 02 13:31:34 Debug: Scripting::fireEvent(): game-select \"/roms/game.zip\" \"Game\" \"nes\" \"Nintendo\""</ID>
-    <ID>MaxLineLength:NavigationDirectionParserTest.kt$NavigationDirectionParserTest$val line = "Aug 02 13:31:34 Debug: Window::logInput(Xbox Wireless Controller): Button 14, isMappedTo=right, value=1"</ID>
-    <ID>MaxLineLength:NavigationDirectionParserTest.kt$NavigationDirectionParserTest$val line = "Aug 02 13:31:34 Debug: Window::logInput(Xbox Wireless Controller): Button 4, isMappedTo=leftshoulder, value=1"</ID>
-    <ID>MaxLineLength:NavigationDirectionParserTest.kt$NavigationDirectionParserTest$val line = "Aug 02 13:31:35 Debug: Window::logInput(Xbox Wireless Controller): Button 13, isMappedTo=left, value=1"</ID>
-    <ID>MaxLineLength:NavigationDirectionTrackerTest.kt$NavigationDirectionTrackerTest$tracker.observeLine("Scripting::fireEvent(): game-select \"/roms/game.zip\" \"Buggy Run\" \"mastersystem\" \"Sega Master System\"")</ID>
-    <ID>MaxLineLength:NavigationDirectionTrackerTest.kt$NavigationDirectionTrackerTest$tracker.observeLine("Scripting::fireEvent(): system-select \"mastersystem\" \"Sega Master System\" \"/roms/mastersystem\" \"\"")</ID>
-    <ID>MaxLineLength:OnboardingScreen.kt$.</ID>
-    <ID>MaxLineLength:OnboardingScreen.kt$validation is LogFolderValidation.FolderNotFound -&gt; Text("This folder doesn't exist. Choose the correct folder.")</ID>
-    <ID>MaxLineLength:OnboardingScreen.kt$validation is MediaFolderValidation.FolderNotFound -&gt; Text("This folder doesn't exist. Choose the correct folder.")</ID>
-    <ID>MaxLineLength:OnboardingViewModelTest.kt$OnboardingViewModelTest$assertEquals(LogFolderValidation.FolderFound(settingsFileFound = true), viewModel.uiState.value.logFolderValidation)</ID>
-    <ID>MaxLineLength:OnboardingViewModelTest.kt$OnboardingViewModelTest$val viewModel = buildViewModel(onboardingRepository = onboardingRepo, installationRepository = installationRepo)</ID>
-    <ID>MaxLineLength:OnboardingViewModelTest.kt$OnboardingViewModelTest.FakeEsdeInstallationRepository$override suspend fun readEventScriptSettings(esdeRootPath: String): EsdeEventScriptSettings?</ID>
-    <ID>MaxLineLength:ReactiveEsdeLogRepositoryTest.kt$ReactiveEsdeLogRepositoryTest$repositoryFactory = { folder -&gt; FakeEsdeLogRepository(exists = folder == "/storage/emulated/0/ES-DE") }</ID>
-    <ID>MaxLineLength:ReadEsdeMediaDirectoryUseCase.kt$ReadEsdeMediaDirectoryUseCase$suspend operator fun invoke(esdeRootPath: String): String?</ID>
-    <ID>MaxLineLength:SetOtherScreenLaunchAppsUseCase.kt$SetOtherScreenLaunchAppsUseCase$suspend operator fun invoke(packageNames: Set&lt;String&gt;)</ID>
-    <ID>MaxLineLength:SettingsContent.kt$text = "Show the Settings gear on the main screen. It's always reachable via the long-press menu regardless of this setting."</ID>
-    <ID>MaxLineLength:SettingsViewModel.kt$SettingsViewModel$_uiState.value = _uiState.value.copy(isValidatingCustomLogosFolder = false, customLogosFolderValidation = result)</ID>
-    <ID>MaxLineLength:SettingsViewModel.kt$SettingsViewModel$_uiState.value = _uiState.value.copy(isValidatingCustomMusicFolder = false, customMusicFolderValidation = result)</ID>
-    <ID>MaxLineLength:SettingsViewModelTest.kt$SettingsViewModelTest$observeCloseCompanionOnQuitEnabledUseCase = ObserveCloseCompanionOnQuitEnabledUseCase(onboardingRepository)</ID>
-    <ID>MaxLineLength:SettingsViewModelTest.kt$SettingsViewModelTest$observeMusicPlayDuringScreensaverUseCase = ObserveMusicPlayDuringScreensaverUseCase(onboardingRepository)</ID>
-    <ID>MaxLineLength:SettingsViewModelTest.kt$SettingsViewModelTest$observeMusicPlayWhileBrowsingGamesUseCase = ObserveMusicPlayWhileBrowsingGamesUseCase(onboardingRepository)</ID>
-    <ID>MaxLineLength:SettingsViewModelTest.kt$SettingsViewModelTest$observeMusicPlayWhileBrowsingSystemsUseCase = ObserveMusicPlayWhileBrowsingSystemsUseCase(onboardingRepository)</ID>
-    <ID>MaxLineLength:SetupSettingsContent.kt$if (settingsFileFound) "settings/es_settings.xml found" else "Folder found, but appears to be the incorrect folder"</ID>
-    <ID>MaxLineLength:UISettingsContent.kt$options = listOf(ScreenBehavior.Nothing, ScreenBehavior.Dim, ScreenBehavior.Black, ScreenBehavior.GameManual)</ID>
-    <ID>MaxLineLength:WidgetCanvas.kt$is WidgetContent.NameFallback -&gt; Unit</ID>
-    <ID>MaxLineLength:WidgetCanvas.kt$is WidgetContent.SystemLogoAsset -&gt; Unit</ID>
-    <ID>MaxLineLength:WidgetColorConfig.kt$Text(text = "Transparency: ${(current.alpha * 100).roundToInt()}%", style = MaterialTheme.typography.titleSmall)</ID>
-    <ID>MaxLineLength:WidgetContent.kt$return WidgetContent.Image(fallbackBackgroundAssetPath, scaleMode, isTransparentOverlay = false, isAsset = true, effects = effects)</ID>
-    <ID>MaxLineLength:WidgetContentResolver.kt$WidgetContentResolver$?.</ID>
-    <ID>MaxLineLength:WidgetContentResolverTest.kt$WidgetContentResolverTest$WidgetContent.Image("/storage/emulated/0/Pictures/cover.jpg", ScaleMode.Fill, isTransparentOverlay = false, isAsset = false)</ID>
-    <ID>MaxLineLength:WidgetContentResolverTest.kt$WidgetContentResolverTest$assertEquals(WidgetContent.Image("/media/fanart.png", ScaleMode.Fill, isTransparentOverlay = false, isAsset = false), content)</ID>
-    <ID>MaxLineLength:WidgetContentResolverTest.kt$WidgetContentResolverTest$assertEquals(WidgetContent.Image("/media/marquee.png", ScaleMode.Fit, isTransparentOverlay = true, isAsset = false), content)</ID>
-    <ID>MaxLineLength:WidgetContentResolverTest.kt$WidgetContentResolverTest$assertEquals(WidgetContent.Image("fallback.webp", ScaleMode.Fill, isTransparentOverlay = false, isAsset = true), content)</ID>
-    <ID>MaxLineLength:WidgetContentResolverTest.kt$WidgetContentResolverTest$assertEquals(WidgetContent.SystemLogoAsset("file:///android_asset/system_logos/dreamcast.svg", ScaleMode.Fit), content)</ID>
-    <ID>MaxLineLength:WidgetContentResolverTest.kt$WidgetContentResolverTest$widgetType = WidgetType.CustomImage(path = "/storage/emulated/0/Pictures/cover.jpg", scaleMode = ScaleMode.Fill)</ID>
-    <ID>MaxLineLength:WidgetImageConfigControls.kt$Text(text = "Blur: ${(current.blurAmount * 100).roundToInt()}%", style = MaterialTheme.typography.titleSmall)</ID>
-    <ID>MaxLineLength:WidgetImageConfigControls.kt$Text(text = "Darken: ${(current.darkenAmount * 100).roundToInt()}%", style = MaterialTheme.typography.titleSmall)</ID>
-    <ID>MaxLineLength:WidgetImageTransitionEligibilityTest.kt$WidgetImageTransitionEligibilityTest$WidgetType.CustomImage("p", ScaleMode.Fill, imageTransitionMode = ImageTransitionMode.Fade).imageTransitionMode</ID>
-    <ID>MaxLineLength:WidgetImageTransitionEligibilityTest.kt$WidgetImageTransitionEligibilityTest$WidgetType.GameMedia(MediaType.Screenshots, ScaleMode.Fill, imageTransitionMode = ImageTransitionMode.Fade).imageTransitionMode</ID>
-    <ID>MaxLineLength:WidgetImageTransitionEligibilityTest.kt$WidgetImageTransitionEligibilityTest$WidgetType.SystemMedia(MediaType.FanArt, ScaleMode.Fill, imageTransitionMode = ImageTransitionMode.Fade).imageTransitionMode</ID>
-    <ID>MaxLineLength:WidgetImageTransitionEligibilityTest.kt$WidgetImageTransitionEligibilityTest$val logo = WidgetType.SystemLogo(ScaleMode.Fill, logoTransitionMode = LogoTransitionMode.Slide, glintEnabled = true)</ID>
-    <ID>MaxLineLength:WidgetImageTransitionEligibilityTest.kt$WidgetImageTransitionEligibilityTest$val widget = WidgetType.GameMedia(MediaType.Covers, ScaleMode.Fill, imageTransitionMode = ImageTransitionMode.Fade)</ID>
-    <ID>MaxLineLength:WidgetImageTransitionEligibilityTest.kt$WidgetImageTransitionEligibilityTest$val widget = WidgetType.GameMedia(MediaType.Screenshots, ScaleMode.Fill, imageTransitionMode = ImageTransitionMode.Fade)</ID>
-    <ID>MaxLineLength:WidgetLayoutMapping.kt$WidgetTypeDto.SystemLogo(scaleMode.toDto(), effects.blurAmount, effects.darkenAmount, logoTransitionMode.toDto(), glintEnabled)</ID>
-    <ID>MaxLineLength:WidgetLayoutMapping.kt$is WidgetType.GameDescription -&gt; WidgetTypeDto.GameDescription(fontSizeSp, textColorArgb, backgroundColorArgb, backgroundAlpha)</ID>
-    <ID>MaxLineLength:WidgetLayoutMapping.kt$private fun PlacedWidget.toDto()</ID>
-    <ID>MaxLineLength:WidgetLayoutMapping.kt$private fun PlacedWidgetDto.toDomain()</ID>
-    <ID>MaxLineLength:WidgetLayoutMappingTest.kt$WidgetLayoutMappingTest$val widget = WidgetType.SystemLogo(ScaleMode.Fit, logoTransitionMode = LogoTransitionMode.Slide, glintEnabled = true)</ID>
-    <ID>MaxLineLength:WidgetTypeDialogs.kt$GlintConfig(enabled = widgetType.glintEnabled) { onChange(widgetType.copy(glintEnabled = it)) }</ID>
-    <ID>MaxLineLength:WidgetTypeDialogs.kt$LogoTransitionPicker(current = widgetType.logoTransitionMode) { onChange(widgetType.copy(logoTransitionMode = it)) }</ID>
-    <ID>MaxLineLength:WidgetTypeDialogs.kt$PanZoomConfig(enabled = widgetType.panZoomEnabled) { onChange(widgetType.copy(panZoomEnabled = it)) }</ID>
-    <ID>MaxLineLength:WidgetsViewModel.kt$WidgetsViewModel$WidgetCanvasState.Showing(widgets, resolveContent(widgets, identity), identity.navigationDirection)</ID>
-    <ID>MaxLineLength:WidgetsViewModel.kt$WidgetsViewModel$neededSystemMediaTypes.associateWith { mediaType -&gt; resolveRandomSystemMediaCached(shortName, mediaType) }</ID>
-    <ID>MaxLineLength:WidgetsViewModel.kt$WidgetsViewModel$val customSystemLogoPath = if (needsCustomLogo) systemShortName?.let { resolveCustomSystemLogo(systemLogoAssetName(it)) } else null</ID>
-    <ID>MaximumLineLength:AppDock.kt$ </ID>
-    <ID>MaximumLineLength:AppDock.kt$private</ID>
-    <ID>MaximumLineLength:AppDockViewModel.kt$AppDockViewModel$ </ID>
-    <ID>MaximumLineLength:AppDockViewModelTest.kt$AppDockViewModelTest$ </ID>
-    <ID>MaximumLineLength:AppDrawer.kt$internal</ID>
-    <ID>MaximumLineLength:AppDrawerViewModel.kt$AppDrawerViewModel$ </ID>
-    <ID>MaximumLineLength:AppDrawerViewModelTest.kt$AppDrawerViewModelTest$ </ID>
-    <ID>MaximumLineLength:AppStateReducerTest.kt$AppStateReducerTest$ </ID>
-    <ID>MaximumLineLength:AutoCollectionAssets.kt$fun</ID>
-    <ID>MaximumLineLength:BuildDrawerItemsTest.kt$BuildDrawerItemsTest$ </ID>
-    <ID>MaximumLineLength:EditWidgetsOverlay.kt$ </ID>
-    <ID>MaximumLineLength:EditWidgetsViewModel.kt$EditWidgetsViewModel$ </ID>
-    <ID>MaximumLineLength:EditWidgetsViewModelTest.kt$EditWidgetsViewModelTest$ </ID>
-    <ID>MaximumLineLength:EsdeEventParserTest.kt$EsdeEventParserTest$ </ID>
     <ID>MaximumLineLength:EsdeLogFileRepositoryTest.kt$EsdeLogFileRepositoryTest$ </ID>
-    <ID>MaximumLineLength:EsdeSettingsParser.kt$EsdeSettingsParser$ </ID>
-    <ID>MaximumLineLength:FileAppDrawerSettingsRepository.kt$FileAppDrawerSettingsRepository$ </ID>
-    <ID>MaximumLineLength:FileDockSettingsRepository.kt$FileDockSettingsRepository$ </ID>
-    <ID>MaximumLineLength:FileEsdeInstallationRepository.kt$FileEsdeInstallationRepository$ </ID>
-    <ID>MaximumLineLength:FileGameMediaRepository.kt$FileGameMediaRepository$ </ID>
-    <ID>MaximumLineLength:FileLastKnownContextRepository.kt$FileLastKnownContextRepository$ </ID>
-    <ID>MaximumLineLength:FileOnboardingRepository.kt$FileOnboardingRepository$ </ID>
-    <ID>MaximumLineLength:FindLegacyScriptFilesUseCase.kt$FindLegacyScriptFilesUseCase$ </ID>
-    <ID>MaximumLineLength:GameManualViewModel.kt$GameManualViewModel$ </ID>
-    <ID>MaximumLineLength:LongPressSettingsMenu.kt$ </ID>
-    <ID>MaximumLineLength:MainActivity.kt$MainActivity$ </ID>
-    <ID>MaximumLineLength:MusicControlsOverlay.kt$ </ID>
-    <ID>MaximumLineLength:MusicPlaybackCoordinatorTest.kt$MusicPlaybackCoordinatorTest$ </ID>
-    <ID>MaximumLineLength:NavigationDirectionParser.kt$NavigationDirectionParser$ </ID>
-    <ID>MaximumLineLength:NavigationDirectionParserTest.kt$NavigationDirectionParserTest$ </ID>
-    <ID>MaximumLineLength:NavigationDirectionTrackerTest.kt$NavigationDirectionTrackerTest$ </ID>
-    <ID>MaximumLineLength:OnboardingScreen.kt$ </ID>
-    <ID>MaximumLineLength:OnboardingViewModelTest.kt$OnboardingViewModelTest$ </ID>
-    <ID>MaximumLineLength:OnboardingViewModelTest.kt$OnboardingViewModelTest.FakeEsdeInstallationRepository$ </ID>
-    <ID>MaximumLineLength:ReactiveEsdeLogRepositoryTest.kt$ReactiveEsdeLogRepositoryTest$ </ID>
-    <ID>MaximumLineLength:ReadEsdeMediaDirectoryUseCase.kt$ReadEsdeMediaDirectoryUseCase$ </ID>
-    <ID>MaximumLineLength:SetOtherScreenLaunchAppsUseCase.kt$SetOtherScreenLaunchAppsUseCase$ </ID>
-    <ID>MaximumLineLength:SettingsViewModel.kt$SettingsViewModel$ </ID>
-    <ID>MaximumLineLength:SettingsViewModelTest.kt$SettingsViewModelTest$ </ID>
-    <ID>MaximumLineLength:SetupSettingsContent.kt$ </ID>
-    <ID>MaximumLineLength:UISettingsContent.kt$ </ID>
-    <ID>MaximumLineLength:WidgetCanvas.kt$ </ID>
-    <ID>MaximumLineLength:WidgetColorConfig.kt$ </ID>
-    <ID>MaximumLineLength:WidgetContent.kt$ </ID>
-    <ID>MaximumLineLength:WidgetContentResolver.kt$WidgetContentResolver$ </ID>
-    <ID>MaximumLineLength:WidgetContentResolverTest.kt$WidgetContentResolverTest$ </ID>
-    <ID>MaximumLineLength:WidgetImageConfigControls.kt$ </ID>
-    <ID>MaximumLineLength:WidgetImageTransitionEligibilityTest.kt$WidgetImageTransitionEligibilityTest$ </ID>
-    <ID>MaximumLineLength:WidgetLayoutMapping.kt$ </ID>
-    <ID>MaximumLineLength:WidgetLayoutMapping.kt$private</ID>
-    <ID>MaximumLineLength:WidgetLayoutMappingTest.kt$WidgetLayoutMappingTest$ </ID>
-    <ID>MaximumLineLength:WidgetTypeDialogs.kt$ </ID>
-    <ID>MaximumLineLength:WidgetsViewModel.kt$WidgetsViewModel$ </ID>
     <ID>NestedBlockDepth:EsdeLogFileRepository.kt$EsdeLogFileRepository$private fun findEventsSinceLastAnchor( file: File, directionTracker: NavigationDirectionTracker, ): List&lt;EsdeEvent&gt;</ID>
-    <ID>ParameterListWrapping:FindLegacyScriptFilesUseCase.kt$FindLegacyScriptFilesUseCase$(esdeRootPath: String)</ID>
-    <ID>ParameterListWrapping:NavigationDirectionParser.kt$NavigationDirectionParser$(rawLine: String)</ID>
-    <ID>ParameterListWrapping:ReadEsdeMediaDirectoryUseCase.kt$ReadEsdeMediaDirectoryUseCase$(esdeRootPath: String)</ID>
-    <ID>ParameterListWrapping:SetOtherScreenLaunchAppsUseCase.kt$SetOtherScreenLaunchAppsUseCase$(packageNames: Set&lt;String&gt;)</ID>
-    <ID>PropertyWrapping:AppDockViewModelTest.kt$AppDockViewModelTest$val repository = FakeDockSettingsRepository(initialDockApps = listOf("com.example.a", "com.example.b", "com.example.c"))</ID>
-    <ID>PropertyWrapping:AppDrawerViewModel.kt$AppDrawerViewModel$val newFolder = AppFolder(id = UUID.randomUUID().toString(), name = name, memberPackageNames = setOf(packageName))</ID>
-    <ID>PropertyWrapping:AppDrawerViewModelTest.kt$AppDrawerViewModelTest$val folder = AppFolder(id = "folder-1", name = "Group", memberPackageNames = setOf("com.example.a", "com.example.b"))</ID>
-    <ID>PropertyWrapping:AppDrawerViewModelTest.kt$AppDrawerViewModelTest$val settingsRepository = FakeAppDrawerSettingsRepository(initialOtherScreenLaunchApps = setOf("com.example.a"))</ID>
-    <ID>PropertyWrapping:BuildDrawerItemsTest.kt$BuildDrawerItemsTest$val folder = AppFolder(id = "folder-1", name = "Group", memberPackageNames = setOf(appA.packageName, "com.example.gone"))</ID>
-    <ID>PropertyWrapping:BuildDrawerItemsTest.kt$BuildDrawerItemsTest$val folder = AppFolder(id = "folder-1", name = "Group", memberPackageNames = setOf(appA.packageName, appB.packageName))</ID>
-    <ID>PropertyWrapping:MainActivity.kt$MainActivity$val appDrawerViewModel: AppDrawerViewModel = viewModel(factory = AppDrawerViewModelFactory(appContainer))</ID>
-    <ID>PropertyWrapping:MainActivity.kt$MainActivity$val dockViewModel: AppDockViewModel = viewModel(factory = AppDockViewModelFactory(appContainer))</ID>
-    <ID>PropertyWrapping:MainActivity.kt$MainActivity$val gameManualViewModel: GameManualViewModel = viewModel(factory = GameManualViewModelFactory(appContainer))</ID>
-    <ID>PropertyWrapping:MainActivity.kt$MainActivity$val manageAppsViewModel: ManageAppsViewModel = viewModel(factory = ManageAppsViewModelFactory(appContainer))</ID>
-    <ID>PropertyWrapping:MainActivity.kt$MainActivity$val settingsViewModel: SettingsViewModel = viewModel(factory = SettingsViewModelFactory(appContainer))</ID>
-    <ID>PropertyWrapping:MainActivity.kt$MainActivity$val widgetsViewModel: WidgetsViewModel = viewModel(factory = WidgetsViewModelFactory(appContainer))</ID>
-    <ID>PropertyWrapping:MusicPlaybackCoordinatorTest.kt$MusicPlaybackCoordinatorTest$val observeConnectionState = ObserveConnectionStateUseCase(logRepository, ObserveAppStateUseCase(logRepository, scope))</ID>
-    <ID>PropertyWrapping:OnboardingViewModelTest.kt$OnboardingViewModelTest$val viewModel = buildViewModel(onboardingRepository = onboardingRepo, installationRepository = installationRepo)</ID>
     <ID>ReturnCount:EsdeEventParser.kt$EsdeEventParser$fun parseLine(rawLine: String): EsdeEvent?</ID>
     <ID>ReturnCount:EsdeLogFileRepository.kt$EsdeLogFileRepository$private fun findEventsSinceLastAnchor( file: File, directionTracker: NavigationDirectionTracker, ): List&lt;EsdeEvent&gt;</ID>
     <ID>ReturnCount:GameListParser.kt$GameListParser$private fun String.extractGameListElement(): String?</ID>
     <ID>ReturnCount:GameListParser.kt$GameListParser$private fun findGameField( content: String, romPath: String, tagName: String, ): String?</ID>
-    <ID>ReturnCount:GameMediaPathResolver.kt$GameMediaPathResolver$fun resolveBaseRelativePath( systemShortName: String, romPath: String, romIsDirectory: Boolean, ): String?</ID>
     <ID>ReturnCount:GamelistFileReader.kt$GamelistFileReader$private fun resolveGamelistFile( root: String, systemShortName: String, romPath: String, ): File?</ID>
     <ID>ReturnCount:MusicPlayerAction.kt$MusicPlayerActionResolver$fun resolve( hasCurrentTrack: Boolean, eligible: Boolean, userPaused: Boolean, isDuckedByVideo: Boolean, duckingMode: MusicDuckingMode, ): MusicPlayerAction</ID>
     <ID>ReturnCount:NavigationDirectionParser.kt$NavigationDirectionParser$fun parseDirectionalPress(rawLine: String): NavigationDirection?</ID>
@@ -521,7 +183,6 @@
     <ID>ReturnCount:NormalizingSvgDecoder.kt$private fun dimensionsOf(openTag: String): Pair&lt;Double, Double&gt;?</ID>
     <ID>ReturnCount:ResolveRetroAchievementsGameUseCase.kt$ResolveRetroAchievementsGameUseCase$suspend operator fun invoke( gameReference: GameReference, gameName: String, ): RetroAchievementsGameMatch</ID>
     <ID>ReturnCount:RetroAchievementsSystemGamesViewModel.kt$RetroAchievementsSystemGamesViewModel$private suspend fun load( signedIn: Boolean, system: CurrentSystem?, )</ID>
-    <ID>ReturnCount:WidgetContent.kt$fun resolveMediaWidgetContent( mediaType: MediaType, scaleMode: ScaleMode, lookup: (MediaType) -&gt; String?, fallbackBackgroundAssetPath: String?, effects: ImageEffects = ImageEffects(), ): WidgetContent</ID>
     <ID>TooManyFunctions:AppDock.kt$com.esde.companion.ui.dock.AppDock.kt</ID>
     <ID>TooManyFunctions:AppDrawer.kt$com.esde.companion.ui.drawer.AppDrawer.kt</ID>
     <ID>TooManyFunctions:ConfigBackupMapping.kt$com.esde.companion.data.backup.ConfigBackupMapping.kt</ID>
@@ -532,19 +193,5 @@
     <ID>TooManyFunctions:SettingsViewModel.kt$SettingsViewModel : ViewModel</ID>
     <ID>TooManyFunctions:UISettingsContent.kt$com.esde.companion.ui.settings.UISettingsContent.kt</ID>
     <ID>TooManyFunctions:WidgetLayoutMapping.kt$com.esde.companion.data.settings.WidgetLayoutMapping.kt</ID>
-    <ID>Wrapping:FileAppDrawerSettingsRepository.kt$FileAppDrawerSettingsRepository$it[HIDDEN_APPS_KEY] ?: emptySet()</ID>
-    <ID>Wrapping:FileDockSettingsRepository.kt$FileDockSettingsRepository$it[DOCK_ENABLED_KEY] ?: false</ID>
-    <ID>Wrapping:FileDockSettingsRepository.kt$FileDockSettingsRepository$it[DOCK_MAX_APPS_KEY] ?: DEFAULT_DOCK_MAX_APPS</ID>
-    <ID>Wrapping:FileLastKnownContextRepository.kt$FileLastKnownContextRepository$it[SYSTEM_SHORT_NAME_KEY]</ID>
-    <ID>Wrapping:FileOnboardingRepository.kt$FileOnboardingRepository$it[CUSTOM_LOGOS_FOLDER_PATH_KEY]</ID>
-    <ID>Wrapping:FileOnboardingRepository.kt$FileOnboardingRepository$it[CUSTOM_MUSIC_FOLDER_PATH_KEY]</ID>
-    <ID>Wrapping:FileOnboardingRepository.kt$FileOnboardingRepository$it[MEDIA_FOLDER_PATH_KEY]</ID>
-    <ID>Wrapping:FileOnboardingRepository.kt$FileOnboardingRepository$it[MUSIC_ENABLED_KEY] ?: false</ID>
-    <ID>Wrapping:FileOnboardingRepository.kt$FileOnboardingRepository$it[ONBOARDING_COMPLETE_KEY] ?: false</ID>
-    <ID>Wrapping:FileOnboardingRepository.kt$FileOnboardingRepository$it[SETTINGS_FAB_VISIBLE_KEY] ?: true</ID>
-    <ID>Wrapping:FileOnboardingRepository.kt$FileOnboardingRepository$it[VIDEO_AUDIO_ENABLED_KEY] ?: true</ID>
-    <ID>Wrapping:WidgetContentResolver.kt$WidgetContentResolver$WidgetContent.Image(it, widgetType.scaleMode, isTransparentOverlay = false, isAsset = false, effects = widgetType.effects)</ID>
-    <ID>Wrapping:WidgetContentResolver.kt$WidgetContentResolver$WidgetContent.Image(it, widgetType.scaleMode, isTransparentOverlay = true, isAsset = false, effects = widgetType.effects)</ID>
-    <ID>Wrapping:WidgetsViewModel.kt$WidgetsViewModel$resolveCustomSystemLogo(systemLogoAssetName(it))</ID>
   </CurrentIssues>
 </SmellBaseline>


### PR DESCRIPTION
## Summary
- Repo-wide mechanical formatting sweep: `ktlintFormat` + `detekt --auto-correct`, plus manual fixes for what autocorrect couldn't handle (missing trailing commas on multi-line argument lists, calls opening mid-line inside a lambda, long single-line string literals split via concatenation, and a handful of ktlint-140/detekt-120-char disagreements resolved with block function bodies per the documented gotcha in CLAUDE.md).
- detekt baseline: **544 -> 191 entries**. Every fully-mechanical formatting rule (ArgumentListWrapping, Wrapping, PropertyWrapping, ParameterListWrapping) is now at **zero**. MaxLineLength/MaximumLineLength dropped from ~50 to 2 residual entries (one test-fixture file with several long realistic log-line literals, left baselined rather than force-reformatted).
- Two new `LongMethod` entries appeared as a side effect of mandatory trailing-comma/wrapping fixes pushing two functions a few lines past the 60-line threshold (`WidgetLayoutMapping.kt$WidgetType.toDto()`, `WidgetsViewModel.kt$resolveContent()`). These are legitimate, not scope creep - flagged as good Phase 5 candidates rather than fought during a formatting-only pass.
- Remaining 191 baseline entries: mostly structural/design-smell rules (LongParameterList, MagicNumber, LongMethod, ReturnCount, EmptyFunctionBlock, CyclomaticComplexMethod, TooManyFunctions) that are Phase 5's scope, plus 39 `Indentation` entries that detekt's own autocorrect and `ktlintFormat` both left unresolved - chasing those further by hand would be disproportionate effort for a mechanical-sweep phase.
- Landed as one PR rather than the plan's suggested batch-by-package split: no other branches are currently in flight (the scenario batching was meant to protect against), and splitting the regenerated baseline correctly across partial file subsets would add real correctness risk for little practical benefit right now.

## Test plan
- [x] `ktlintCheck detekt testDebugUnitTest` all pass
- [x] Confirmed baseline reduction is real (not baseline-cheating): every removed entry was independently verified fixed by running detekt against a baseline with only that entry stripped, then fixing the reported violation using detekt's own reported signature text (not hand-guessed)