### PR TITLE
Technical debt paydown: Phase 5 (MagicNumber sweep)

### DIFF
--- a/app/src/main/java/com/esde/companion/data/media/NormalizingSvgDecoder.kt
+++ b/app/src/main/java/com/esde/companion/data/media/NormalizingSvgDecoder.kt
@@ -28,6 +28,13 @@ internal const val NORMALIZED_LONG_EDGE = 3000.0
  * needed never requires reading a whole (possibly huge) document. */
 private const val OPEN_TAG_PEEK_BYTES = 16_384L
 
+/** A viewBox is exactly "minX minY width height". */
+private const val VIEW_BOX_PART_COUNT = 4
+private const val VIEW_BOX_HEIGHT_INDEX = 3
+
+/** In `(\bname\s*=\s*")([^"]*)(")`, group 3 is the closing quote. */
+private const val CLOSING_QUOTE_GROUP_INDEX = 3
+
 /**
  * Wraps [SvgDecoder] to work around a real rendering-quality issue in the androidsvg
  * library it delegates to: curve-flattening tolerance is computed in the SVG's own
@@ -182,8 +189,8 @@ private fun scaleFor(
 
 private fun parseViewBox(value: String): ViewBox? {
     val parts = value.trim().split(Regex("""[\s,]+""")).mapNotNull { it.toDoubleOrNull() }
-    if (parts.size != 4) return null
-    return ViewBox(minX = parts[0], minY = parts[1], width = parts[2], height = parts[3])
+    if (parts.size != VIEW_BOX_PART_COUNT) return null
+    return ViewBox(minX = parts[0], minY = parts[1], width = parts[2], height = parts[VIEW_BOX_HEIGHT_INDEX])
 }
 
 private fun parseUnitless(value: String): Double? = value.removeSuffix("px").toDoubleOrNull()
@@ -201,7 +208,7 @@ private fun setAttr(
 ): String {
     val attrRegex = Regex("""(\b$name\s*=\s*")([^"]*)(")""", RegexOption.IGNORE_CASE)
     return if (attrRegex.containsMatchIn(tag)) {
-        attrRegex.replace(tag) { "${it.groupValues[1]}$value${it.groupValues[3]}" }
+        attrRegex.replace(tag) { "${it.groupValues[1]}$value${it.groupValues[CLOSING_QUOTE_GROUP_INDEX]}" }
     } else {
         tag.replaceFirst("<svg", "<svg $name=\"$value\"")
     }

--- a/app/src/main/java/com/esde/companion/data/settings/FileAppDrawerSettingsRepository.kt
+++ b/app/src/main/java/com/esde/companion/data/settings/FileAppDrawerSettingsRepository.kt
@@ -9,6 +9,9 @@ import com.esde.companion.domain.repository.AppDrawerSettingsRepository
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 
+private const val MIN_GRID_COLUMNS = 3
+private const val MAX_GRID_COLUMNS = 6
+
 /**
  * DataStore-backed [AppDrawerSettingsRepository]. [context] is expected to be an
  * application context (see AppContainer), not an Activity context - same note as
@@ -27,7 +30,9 @@ class FileAppDrawerSettingsRepository(
         }
 
     override suspend fun setGridColumns(columns: Int) {
-        context.appDrawerSettingsDataStore.edit { it[GRID_COLUMNS_KEY] = columns.coerceIn(3, 6) }
+        context.appDrawerSettingsDataStore.edit {
+            it[GRID_COLUMNS_KEY] = columns.coerceIn(MIN_GRID_COLUMNS, MAX_GRID_COLUMNS)
+        }
     }
 
     override fun observeGridColumns(): Flow<Int> =

--- a/app/src/main/java/com/esde/companion/data/settings/FileDockSettingsRepository.kt
+++ b/app/src/main/java/com/esde/companion/data/settings/FileDockSettingsRepository.kt
@@ -31,7 +31,9 @@ class FileDockSettingsRepository(
         }
 
     override suspend fun setDockMaxApps(maxApps: Int) {
-        context.dockSettingsDataStore.edit { it[DOCK_MAX_APPS_KEY] = maxApps.coerceIn(2, 5) }
+        context.dockSettingsDataStore.edit {
+            it[DOCK_MAX_APPS_KEY] = maxApps.coerceIn(MIN_DOCK_MAX_APPS, MAX_DOCK_MAX_APPS)
+        }
     }
 
     override fun observeDockMaxApps(): Flow<Int> =
@@ -59,6 +61,8 @@ class FileDockSettingsRepository(
 
     private companion object {
         const val DEFAULT_DOCK_MAX_APPS = 5
+        const val MIN_DOCK_MAX_APPS = 2
+        const val MAX_DOCK_MAX_APPS = 5
 
         val DOCK_ENABLED_KEY = booleanPreferencesKey("dock_enabled")
         val DOCK_MAX_APPS_KEY = intPreferencesKey("dock_max_apps")

--- a/app/src/main/java/com/esde/companion/data/settings/FileOnboardingRepository.kt
+++ b/app/src/main/java/com/esde/companion/data/settings/FileOnboardingRepository.kt
@@ -23,6 +23,9 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.withContext
 import java.io.File
 
+private const val MIN_PERCENT = 0
+private const val MAX_PERCENT = 100
+
 /**
  * DataStore-backed [OnboardingRepository]. Folder existence/log-file checks are plain
  * File I/O (this app isn't Play-Store distributed, so MANAGE_EXTERNAL_STORAGE is granted
@@ -137,7 +140,9 @@ class FileOnboardingRepository(
         }
 
     override suspend fun setGamePlayingDimPercent(percent: Int) {
-        context.onboardingDataStore.edit { it[GAME_PLAYING_DIM_PERCENT_KEY] = percent.coerceIn(0, 100) }
+        context.onboardingDataStore.edit {
+            it[GAME_PLAYING_DIM_PERCENT_KEY] = percent.coerceIn(MIN_PERCENT, MAX_PERCENT)
+        }
     }
 
     override fun observeGamePlayingDimPercent(): Flow<Int> =
@@ -155,7 +160,9 @@ class FileOnboardingRepository(
         }
 
     override suspend fun setScreensaverDimPercent(percent: Int) {
-        context.onboardingDataStore.edit { it[SCREENSAVER_DIM_PERCENT_KEY] = percent.coerceIn(0, 100) }
+        context.onboardingDataStore.edit {
+            it[SCREENSAVER_DIM_PERCENT_KEY] = percent.coerceIn(MIN_PERCENT, MAX_PERCENT)
+        }
     }
 
     override fun observeScreensaverDimPercent(): Flow<Int> =
@@ -228,7 +235,7 @@ class FileOnboardingRepository(
         }
 
     override suspend fun setOverlayOpacityPercent(percent: Int) {
-        context.onboardingDataStore.edit { it[OVERLAY_OPACITY_KEY] = percent.coerceIn(0, 100) }
+        context.onboardingDataStore.edit { it[OVERLAY_OPACITY_KEY] = percent.coerceIn(MIN_PERCENT, MAX_PERCENT) }
     }
 
     override fun observeOverlayOpacityPercent(): Flow<Int> =

--- a/app/src/main/java/com/esde/companion/domain/parser/EsdeEventParser.kt
+++ b/app/src/main/java/com/esde/companion/domain/parser/EsdeEventParser.kt
@@ -85,12 +85,12 @@ class EsdeEventParser {
     }
 
     private fun List<String>.toGameArgs(): GameArgs? {
-        val romPath = getOrNull(0) ?: return null
+        val romPath = getOrNull(GAME_ARG_ROM_PATH_INDEX) ?: return null
         return GameArgs(
             romPath = romPath,
-            gameName = getOrElse(1) { "" },
-            systemShortName = getOrElse(2) { "" },
-            systemFullName = getOrElse(3) { "" },
+            gameName = getOrElse(GAME_ARG_GAME_NAME_INDEX) { "" },
+            systemShortName = getOrElse(GAME_ARG_SYSTEM_SHORT_NAME_INDEX) { "" },
+            systemFullName = getOrElse(GAME_ARG_SYSTEM_FULL_NAME_INDEX) { "" },
         )
     }
 
@@ -105,6 +105,11 @@ class EsdeEventParser {
         const val FIRE_EVENT_MARKER = "Scripting::fireEvent():"
         const val WINDOW_RELOAD_MARKER = "Window size has changed from"
         const val GAME_SYSTEMS_RELOAD_MARKER = "Populating game systems"
+
+        const val GAME_ARG_ROM_PATH_INDEX = 0
+        const val GAME_ARG_GAME_NAME_INDEX = 1
+        const val GAME_ARG_SYSTEM_SHORT_NAME_INDEX = 2
+        const val GAME_ARG_SYSTEM_FULL_NAME_INDEX = 3
 
         // Splitting on this exact 3-char sequence (rather than matching independent
         // "..." groups) is what lets a field's own content safely contain unescaped

--- a/app/src/main/java/com/esde/companion/ui/CornerButtonMetrics.kt
+++ b/app/src/main/java/com/esde/companion/ui/CornerButtonMetrics.kt
@@ -40,11 +40,15 @@ val CORNER_BUTTON_EDGE_PADDING = 16.dp
  * translucent overlay surface in the app reads as one consistent family of shapes. */
 private val CORNER_BUTTON_SHAPE = RoundedCornerShape(16.dp)
 
+/** Below this luminance, the surface reads as dark mode - same threshold
+ * MusicControlsOverlay/AppDock/AppDrawer use for their own theme detection. */
+private const val DARK_THEME_LUMINANCE_THRESHOLD = 0.5f
+
 /** Black-on-dark/white-on-light background+content color pair shared by [CornerFab] and
  * [WideCornerFab], factored out so both pick up the same theme-aware styling by construction. */
 @Composable
 private fun cornerButtonColors(): Pair<Color, Color> {
-    val isDarkTheme = MaterialTheme.colorScheme.surface.luminance() < 0.5f
+    val isDarkTheme = MaterialTheme.colorScheme.surface.luminance() < DARK_THEME_LUMINANCE_THRESHOLD
     return if (isDarkTheme) Color.Black to Color.White else Color.White to Color.Black
 }
 

--- a/app/src/main/java/com/esde/companion/ui/MainActivity.kt
+++ b/app/src/main/java/com/esde/companion/ui/MainActivity.kt
@@ -171,6 +171,9 @@ private val LONG_PRESS_MENU_BLUR_RADIUS = 4.dp
 // apps list, not a hardcoded constant) - this is the one call site that needs it.
 private const val ESDE_PACKAGE_NAME = "org.es_de.frontend"
 
+/** How long the music controls panel stays revealed before auto-hiding. */
+private const val MUSIC_CONTROLS_AUTO_HIDE_DELAY_MS = 4_000L
+
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -563,7 +566,7 @@ class MainActivity : ComponentActivity() {
                             // doesn't change filePath, so it still doesn't reset the timer.
                             LaunchedEffect(musicControlsRevealed, musicTrack?.filePath) {
                                 if (musicControlsRevealed) {
-                                    delay(4_000)
+                                    delay(MUSIC_CONTROLS_AUTO_HIDE_DELAY_MS)
                                     musicControlsRevealed = false
                                 }
                             }

--- a/app/src/main/java/com/esde/companion/ui/dock/AppDock.kt
+++ b/app/src/main/java/com/esde/companion/ui/dock/AppDock.kt
@@ -73,18 +73,23 @@ private val SLOT_SPACING = 16.dp
  * collisions (e.g. a bright icon over bright widget art) - see DockPreview's kdoc. */
 private const val DOCK_PREVIEW_ALPHA = 0.65f
 
+/** Below this luminance, the surface reads as dark mode - same threshold
+ * MusicControlsOverlay/CornerButtonMetrics/AppDrawer use for their own theme detection. */
+private const val DARK_THEME_LUMINANCE_THRESHOLD = 0.5f
+
 /** Dock background base color: black in dark mode, white in light mode - same
  * theme-detection approach as MusicControlsOverlay's content/background colors. */
 @Composable
 private fun dockBackgroundColor(): Color {
-    return if (MaterialTheme.colorScheme.surface.luminance() < 0.5f) Color.Black else Color.White
+    val isDark = MaterialTheme.colorScheme.surface.luminance() < DARK_THEME_LUMINANCE_THRESHOLD
+    return if (isDark) Color.Black else Color.White
 }
 
 /** Empty-slot border/icon color: the inverse of [dockBackgroundColor], so the "add app"
  * placeholder stays visible against the dock's background in either theme. */
 @Composable
 private fun dockContentColor(): Color =
-    if (MaterialTheme.colorScheme.surface.luminance() < 0.5f) {
+    if (MaterialTheme.colorScheme.surface.luminance() < DARK_THEME_LUMINANCE_THRESHOLD) {
         Color.White.copy(
             alpha = 0.3f,
         )
@@ -99,7 +104,8 @@ private fun dockContentColor(): Color =
  * ambient content color happens to be. */
 @Composable
 private fun appDrawerShortcutIconTint(): Color {
-    return if (MaterialTheme.colorScheme.surface.luminance() < 0.5f) Color.White else Color.Black
+    val isDark = MaterialTheme.colorScheme.surface.luminance() < DARK_THEME_LUMINANCE_THRESHOLD
+    return if (isDark) Color.White else Color.Black
 }
 
 private fun DockSize.iconDp(): Dp =

--- a/app/src/main/java/com/esde/companion/ui/drawer/AppDrawer.kt
+++ b/app/src/main/java/com/esde/companion/ui/drawer/AppDrawer.kt
@@ -106,18 +106,24 @@ private const val MAX_MOSAIC_ICONS = 4
 private val FOLDER_MOSAIC_CELL_SIZE = 24.dp
 private val FOLDER_MOSAIC_SPACING = 2.dp
 
+/** Below this luminance, the surface reads as dark mode - same threshold
+ * MusicControlsOverlay/CornerButtonMetrics/AppDock use for their own theme detection. */
+private const val DARK_THEME_LUMINANCE_THRESHOLD = 0.5f
+
 /** Drawer background base color: black in dark mode, white in light mode - matches
  * AppDock's [dockBackgroundColor] so the drawer and dock read as one consistent surface. */
 @Composable
 internal fun drawerBackgroundColor(): Color {
-    return if (MaterialTheme.colorScheme.surface.luminance() < 0.5f) Color.Black else Color.White
+    val isDark = MaterialTheme.colorScheme.surface.luminance() < DARK_THEME_LUMINANCE_THRESHOLD
+    return if (isDark) Color.Black else Color.White
 }
 
 /** App label text color: the inverse of [drawerBackgroundColor], so labels stay readable
  * against the drawer's background in either theme. */
 @Composable
 internal fun drawerContentColor(): Color {
-    return if (MaterialTheme.colorScheme.surface.luminance() < 0.5f) Color.White else Color.Black
+    val isDark = MaterialTheme.colorScheme.surface.luminance() < DARK_THEME_LUMINANCE_THRESHOLD
+    return if (isDark) Color.White else Color.Black
 }
 
 /** Two-step "add to folder" flow state, hoisted here (mirrors how AppDock hoists its own

--- a/app/src/main/java/com/esde/companion/ui/main/LongPressSettingsMenu.kt
+++ b/app/src/main/java/com/esde/companion/ui/main/LongPressSettingsMenu.kt
@@ -94,6 +94,10 @@ import kotlinx.coroutines.launch
  * of trying it. */
 private const val EASTER_EGG_TAP_THRESHOLD = 7
 
+/** Slide/fade durations for the Home -> Category -> ManageApps drill-down transition. */
+private const val PAGE_SLIDE_DURATION_MS = 220
+private const val PAGE_FADE_OUT_DURATION_MS = 150
+
 private val EasterEggMessages =
     listOf(
         "It's dangerous to go alone! Take this.",
@@ -278,13 +282,21 @@ fun LongPressSettingsMenu(
                         val enteringDeeper = targetState.depth > initialState.depth
                         val slideDistance = { width: Int -> width / 3 }
                         if (enteringDeeper) {
-                            (slideInHorizontally(tween(220), slideDistance) + fadeIn(tween(220)))
-                                .togetherWith(
-                                    slideOutHorizontally(tween(220)) { -slideDistance(it) } + fadeOut(tween(150)),
-                                )
+                            (
+                                slideInHorizontally(tween(PAGE_SLIDE_DURATION_MS), slideDistance) +
+                                    fadeIn(tween(PAGE_SLIDE_DURATION_MS))
+                            ).togetherWith(
+                                slideOutHorizontally(tween(PAGE_SLIDE_DURATION_MS)) { -slideDistance(it) } +
+                                    fadeOut(tween(PAGE_FADE_OUT_DURATION_MS)),
+                            )
                         } else {
-                            (slideInHorizontally(tween(220)) { -slideDistance(it) } + fadeIn(tween(220)))
-                                .togetherWith(slideOutHorizontally(tween(220), slideDistance) + fadeOut(tween(150)))
+                            (
+                                slideInHorizontally(tween(PAGE_SLIDE_DURATION_MS)) { -slideDistance(it) } +
+                                    fadeIn(tween(PAGE_SLIDE_DURATION_MS))
+                            ).togetherWith(
+                                slideOutHorizontally(tween(PAGE_SLIDE_DURATION_MS), slideDistance) +
+                                    fadeOut(tween(PAGE_FADE_OUT_DURATION_MS)),
+                            )
                         }
                     },
                     label = "longPressSettingsContent",

--- a/app/src/main/java/com/esde/companion/ui/music/MusicControlsOverlay.kt
+++ b/app/src/main/java/com/esde/companion/ui/music/MusicControlsOverlay.kt
@@ -36,6 +36,10 @@ private val ICON_BUTTON_SIZE = 48.dp
 private val ROW_HORIZONTAL_PADDING = 12.dp
 private val TITLE_END_PADDING = 8.dp
 
+/** Below this luminance, the surface reads as dark mode - same threshold
+ * CornerButtonMetrics/AppDock/AppDrawer use for their own theme detection. */
+private const val DARK_THEME_LUMINANCE_THRESHOLD = 0.5f
+
 /**
  * Small track title + play/pause + next card, revealed by MainActivity's music FAB.
  * Renders nothing while [MusicPlaybackState.Stopped] (no track loaded yet).
@@ -82,7 +86,7 @@ fun MusicControlsOverlay(
     if (track == null) return
 
     val isPlaying = playbackState is MusicPlaybackState.Playing
-    val isDarkTheme = MaterialTheme.colorScheme.surface.luminance() < 0.5f
+    val isDarkTheme = MaterialTheme.colorScheme.surface.luminance() < DARK_THEME_LUMINANCE_THRESHOLD
     val backgroundColor = if (isDarkTheme) Color.Black else Color.White
     val contentColor = if (isDarkTheme) Color.White else Color.Black
 

--- a/app/src/main/java/com/esde/companion/ui/onboarding/OnboardingScreen.kt
+++ b/app/src/main/java/com/esde/companion/ui/onboarding/OnboardingScreen.kt
@@ -48,20 +48,27 @@ import com.esde.companion.domain.model.MediaFolderValidation
 import com.esde.companion.ui.theme.LocalIsDarkTheme
 import com.esde.companion.ui.widgets.fallbackBackgroundAssetPath
 
-/** Fixed position in the wizard's forward order (see OnboardingStep's kdoc) - used purely
- * to pick the step-transition slide direction below, since [OnboardingStep] is a sealed
- * class (no built-in ordinal) and some steps are conditionally skipped, so adjacent steps
- * in a given run aren't always adjacent here. */
+/** Forward order (see OnboardingStep's kdoc) - a plain list rather than a `when`-mapped
+ * ordinal since [OnboardingStep] is a sealed class with no built-in ordinal. */
+private val ORDERED_ONBOARDING_STEPS =
+    listOf(
+        OnboardingStep.Permission,
+        OnboardingStep.EsdeFolder,
+        OnboardingStep.MediaFolder,
+        OnboardingStep.LegacyScripts,
+        OnboardingStep.EventScriptSettings,
+        OnboardingStep.LiveLogCheck,
+    )
+
+/** Fixed position in the wizard's forward order - used purely to pick the step-transition
+ * slide direction below, since some steps are conditionally skipped, so adjacent steps in
+ * a given run aren't always adjacent here. */
 private val OnboardingStep.order: Int
-    get() =
-        when (this) {
-            OnboardingStep.Permission -> 0
-            OnboardingStep.EsdeFolder -> 1
-            OnboardingStep.MediaFolder -> 2
-            OnboardingStep.LegacyScripts -> 3
-            OnboardingStep.EventScriptSettings -> 4
-            OnboardingStep.LiveLogCheck -> 5
-        }
+    get() = ORDERED_ONBOARDING_STEPS.indexOf(this)
+
+/** Slide/fade durations for the step-to-step wizard transition. */
+private const val STEP_SLIDE_DURATION_MS = 220
+private const val STEP_FADE_OUT_DURATION_MS = 150
 
 /** Onboarding text renders directly over the themed fallback background image rather than
  * an opaque Material surface, so it can't rely on colorScheme.onBackground/onSurface for
@@ -132,15 +139,21 @@ fun OnboardingScreen(
                             val movingForward = targetState.order > initialState.order
                             val slideDistance = { width: Int -> width / 3 }
                             if (movingForward) {
-                                (slideInHorizontally(tween(220)) { slideDistance(it) } + fadeIn(tween(220)))
-                                    .togetherWith(
-                                        slideOutHorizontally(tween(220)) { -slideDistance(it) } + fadeOut(tween(150)),
-                                    )
+                                (
+                                    slideInHorizontally(tween(STEP_SLIDE_DURATION_MS)) { slideDistance(it) } +
+                                        fadeIn(tween(STEP_SLIDE_DURATION_MS))
+                                ).togetherWith(
+                                    slideOutHorizontally(tween(STEP_SLIDE_DURATION_MS)) { -slideDistance(it) } +
+                                        fadeOut(tween(STEP_FADE_OUT_DURATION_MS)),
+                                )
                             } else {
-                                (slideInHorizontally(tween(220)) { -slideDistance(it) } + fadeIn(tween(220)))
-                                    .togetherWith(
-                                        slideOutHorizontally(tween(220)) { slideDistance(it) } + fadeOut(tween(150)),
-                                    )
+                                (
+                                    slideInHorizontally(tween(STEP_SLIDE_DURATION_MS)) { -slideDistance(it) } +
+                                        fadeIn(tween(STEP_SLIDE_DURATION_MS))
+                                ).togetherWith(
+                                    slideOutHorizontally(tween(STEP_SLIDE_DURATION_MS)) { slideDistance(it) } +
+                                        fadeOut(tween(STEP_FADE_OUT_DURATION_MS)),
+                                )
                             }
                         },
                         label = "onboardingStepContent",

--- a/app/src/main/java/com/esde/companion/ui/video/VideoOverlayScreen.kt
+++ b/app/src/main/java/com/esde/companion/ui/video/VideoOverlayScreen.kt
@@ -30,6 +30,8 @@ import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.delay
 import java.io.File
 
+private const val MILLIS_PER_SECOND = 1000L
+
 /**
  * Opaque full-screen video cover - see MainActivity's showVideoOverlay for the gating
  * that decides when this is composed at all.
@@ -181,7 +183,7 @@ private suspend fun transitionToVideo(
     val incoming = createIncomingPlayer(context, videoPath, displayedSlot.current, ready, onPlaybackEvent)
 
     try {
-        delay(settings.delaySeconds * 1000L)
+        delay(settings.delaySeconds * MILLIS_PER_SECOND)
         incoming.play()
         ready.await()
 

--- a/app/src/main/java/com/esde/companion/ui/widgets/AnimatedLogoImage.kt
+++ b/app/src/main/java/com/esde/companion/ui/widgets/AnimatedLogoImage.kt
@@ -54,6 +54,12 @@ private const val GLINT_PEAK_ALPHA = 0.35f
  * a specular highlight has in real materials, rather than relying on brightness alone. */
 private const val GLINT_FRINGE_ALPHA = 0.2f
 
+/** Gradient stop positions for the glint streak's fringe-peak-fringe shape - symmetric
+ * around the 0.5 midpoint, see the colorStops in the glint drawWithContent block. */
+private const val GLINT_FRINGE_START_STOP = 0.35f
+private const val GLINT_PEAK_STOP = 0.5f
+private const val GLINT_FRINGE_END_STOP = 0.65f
+
 /** Thickness of the visible glint streak (the gradient's transparent-peak-transparent
  * span), fixed and independent of the widget's own size - see [glintBandOffsets]'s kdoc
  * for why this must be decoupled from [GLINT_TILT_DEGREES]/height, not derived from them. */
@@ -241,9 +247,12 @@ fun AnimatedLogoImage(
                                                 colorStops =
                                                     arrayOf(
                                                         0f to Color.Transparent,
-                                                        0.35f to Color.Black.copy(alpha = GLINT_FRINGE_ALPHA),
-                                                        0.5f to Color.White.copy(alpha = GLINT_PEAK_ALPHA),
-                                                        0.65f to Color.Black.copy(alpha = GLINT_FRINGE_ALPHA),
+                                                        GLINT_FRINGE_START_STOP to
+                                                            Color.Black.copy(alpha = GLINT_FRINGE_ALPHA),
+                                                        GLINT_PEAK_STOP to
+                                                            Color.White.copy(alpha = GLINT_PEAK_ALPHA),
+                                                        GLINT_FRINGE_END_STOP to
+                                                            Color.Black.copy(alpha = GLINT_FRINGE_ALPHA),
                                                         1f to Color.Transparent,
                                                     ),
                                                 start = start,

--- a/app/src/main/java/com/esde/companion/ui/widgets/ScrollingText.kt
+++ b/app/src/main/java/com/esde/companion/ui/widgets/ScrollingText.kt
@@ -23,6 +23,7 @@ private const val PAUSE_AT_TOP_MS = 4_500L
 private const val PAUSE_AT_BOTTOM_MS = 7_000L
 private const val PIXELS_PER_SECOND = 35f
 private const val MIN_SCROLL_DURATION_MS = 600
+private const val MILLIS_PER_SECOND = 1000
 
 /**
  * Renders [text] wrapped to the available width. If the wrapped content is taller than
@@ -78,7 +79,8 @@ fun ScrollingText(
 
         val maxValue = scrollState.maxValue
         if (maxValue <= 0) return@LaunchedEffect
-        val scrollDurationMs = ((maxValue / PIXELS_PER_SECOND) * 1000).toInt().coerceAtLeast(MIN_SCROLL_DURATION_MS)
+        val scrollDurationMs =
+            ((maxValue / PIXELS_PER_SECOND) * MILLIS_PER_SECOND).toInt().coerceAtLeast(MIN_SCROLL_DURATION_MS)
         val spec = tween<Float>(durationMillis = scrollDurationMs, easing = LinearEasing)
 
         while (true) {

--- a/app/src/main/java/com/esde/companion/ui/widgets/edit/EditWidgetsViewModel.kt
+++ b/app/src/main/java/com/esde/companion/ui/widgets/edit/EditWidgetsViewModel.kt
@@ -48,6 +48,10 @@ import java.util.UUID
  * for the person to then drag and resize into place. */
 private const val DEFAULT_NEW_WIDGET_SPAN = 4
 
+/** Shown only until the real Settings-backed value's first emission arrives. */
+private const val DEFAULT_DOCK_OPACITY_PERCENT = 80
+private const val DEFAULT_DOCK_MAX_APPS = 5
+
 /**
  * Drives the edit-mode overlay. Unlike the live WidgetsViewModel, [widgets] here is a
  * local, mutable snapshot rather than a continuous subscription to the repository -
@@ -106,11 +110,15 @@ class EditWidgetsViewModel(
 
     val dockOpacityPercent: StateFlow<Int> =
         observeOverlayOpacity()
-            .stateIn(viewModelScope, SharingStarted.WhileSubscribed(stopTimeoutMillis = 5_000), 80)
+            .stateIn(
+                viewModelScope,
+                SharingStarted.WhileSubscribed(stopTimeoutMillis = 5_000),
+                DEFAULT_DOCK_OPACITY_PERCENT,
+            )
 
     val dockMaxApps: StateFlow<Int> =
         observeDockMaxApps()
-            .stateIn(viewModelScope, SharingStarted.WhileSubscribed(stopTimeoutMillis = 5_000), 5)
+            .stateIn(viewModelScope, SharingStarted.WhileSubscribed(stopTimeoutMillis = 5_000), DEFAULT_DOCK_MAX_APPS)
 
     /** Same resolution as AppDockViewModel.dockItems (pinned package names -> InstalledApp,
      * capped to maxApps, with APP_DRAWER_SHORTCUT_PACKAGE_NAME resolving to the synthetic

--- a/app/src/main/java/com/esde/companion/ui/widgets/edit/WidgetColorConfig.kt
+++ b/app/src/main/java/com/esde/companion/ui/widgets/edit/WidgetColorConfig.kt
@@ -31,27 +31,28 @@ import com.esde.companion.domain.model.WidgetType
 import java.util.Locale
 import kotlin.math.roundToInt
 
+private const val PRESET_BLACK = 0xFF000000L
+private const val PRESET_WHITE = 0xFFFFFFFFL
+private const val PRESET_GRAY = 0xFF9E9E9EL
+private const val PRESET_RED = 0xFFF44336L
+private const val PRESET_BLUE = 0xFF2196F3L
+private const val PRESET_GREEN = 0xFF4CAF50L
+private const val PRESET_YELLOW = 0xFFFFEB3BL
+private const val PRESET_PURPLE = 0xFF9C27B0L
+
 /** Fixed preset palette - a full custom color picker (hue/saturation wheel) is more
  * than this widget type needs for a first pass; these presets cover the common cases
  * (tint/darken behind other widgets) with a much simpler UI. */
 internal val COLOR_PRESETS =
     listOf(
-        // black
-        0xFF000000L,
-        // white
-        0xFFFFFFFFL,
-        // gray
-        0xFF9E9E9EL,
-        // red
-        0xFFF44336L,
-        // blue
-        0xFF2196F3L,
-        // green
-        0xFF4CAF50L,
-        // yellow
-        0xFFFFEB3BL,
-        // purple
-        0xFF9C27B0L,
+        PRESET_BLACK,
+        PRESET_WHITE,
+        PRESET_GRAY,
+        PRESET_RED,
+        PRESET_BLUE,
+        PRESET_GREEN,
+        PRESET_YELLOW,
+        PRESET_PURPLE,
     )
 
 @Composable
@@ -175,12 +176,17 @@ internal fun HexColorInput(
     )
 }
 
-internal fun Long.toHexRgbString(): String = String.format(Locale.ROOT, "%06X", this and 0xFFFFFF)
+private const val HEX_RGB_LENGTH = 6
+private const val HEX_RADIX = 16
+private const val RGB_MASK = 0xFFFFFFL
+private const val OPAQUE_ALPHA_MASK = 0xFF000000L
+
+internal fun Long.toHexRgbString(): String = String.format(Locale.ROOT, "%06X", this and RGB_MASK)
 
 internal fun parseHexColor(text: String): Long? {
     val cleaned = text.removePrefix("#").trim()
-    if (cleaned.length != 6 || cleaned.any { it !in HEX_CHARS }) return null
-    return cleaned.toLongOrNull(16)?.let { 0xFF000000L or it }
+    if (cleaned.length != HEX_RGB_LENGTH || cleaned.any { it !in HEX_CHARS }) return null
+    return cleaned.toLongOrNull(HEX_RADIX)?.let { OPAQUE_ALPHA_MASK or it }
 }
 
 private val HEX_CHARS = "0123456789abcdefABCDEF".toSet()

--- a/config/detekt/baseline.xml
+++ b/config/detekt/baseline.xml
@@ -132,43 +132,6 @@
     <ID>LongParameterList:WidgetResizeGeometry.kt$( edge: ResizeEdge, widget: PlacedWidget, grid: GridDimensions, cellWidth: Dp, cellHeight: Dp, onResize: (widgetId: String, gridColumn: Int, gridRow: Int, columnSpan: Int, rowSpan: Int) -&gt; Unit, onDragStateChanged: (Boolean) -&gt; Unit, onDragEnd: () -&gt; Unit, modifier: Modifier = Modifier, )</ID>
     <ID>LongParameterList:WidgetsViewModel.kt$WidgetsViewModel$( observeConnectionState: ObserveConnectionStateUseCase, private val observeWidgetCanvas: ObserveWidgetCanvasUseCase, private val resolveGameMedia: ResolveGameMediaUseCase, private val resolveRandomSystemMedia: ResolveRandomSystemMediaUseCase, private val resolveGameDescription: ResolveGameDescriptionUseCase, private val resolveGameRating: ResolveGameRatingUseCase, private val resolveCustomSystemImage: ResolveCustomSystemImageUseCase, private val resolveCustomSystemLogo: ResolveCustomSystemLogoUseCase, private val resolveBundledSystemLogo: ResolveBundledSystemLogoUseCase, )</ID>
     <ID>LoopWithTooManyJumpStatements:GameListParser.kt$GameListParser$for</ID>
-    <ID>MagicNumber:AnimatedLogoImage.kt$0.35f</ID>
-    <ID>MagicNumber:AnimatedLogoImage.kt$0.5f</ID>
-    <ID>MagicNumber:AnimatedLogoImage.kt$0.65f</ID>
-    <ID>MagicNumber:AppDock.kt$0.5f</ID>
-    <ID>MagicNumber:AppDrawer.kt$0.5f</ID>
-    <ID>MagicNumber:CornerButtonMetrics.kt$0.5f</ID>
-    <ID>MagicNumber:EditWidgetsViewModel.kt$EditWidgetsViewModel$5</ID>
-    <ID>MagicNumber:EditWidgetsViewModel.kt$EditWidgetsViewModel$80</ID>
-    <ID>MagicNumber:EsdeEventParser.kt$EsdeEventParser$3</ID>
-    <ID>MagicNumber:FileAppDrawerSettingsRepository.kt$FileAppDrawerSettingsRepository$3</ID>
-    <ID>MagicNumber:FileAppDrawerSettingsRepository.kt$FileAppDrawerSettingsRepository$6</ID>
-    <ID>MagicNumber:FileDockSettingsRepository.kt$FileDockSettingsRepository$5</ID>
-    <ID>MagicNumber:FileOnboardingRepository.kt$FileOnboardingRepository$100</ID>
-    <ID>MagicNumber:LongPressSettingsMenu.kt$150</ID>
-    <ID>MagicNumber:LongPressSettingsMenu.kt$220</ID>
-    <ID>MagicNumber:MainActivity.kt$MainActivity$4_000</ID>
-    <ID>MagicNumber:MusicControlsOverlay.kt$0.5f</ID>
-    <ID>MagicNumber:NormalizingSvgDecoder.kt$3</ID>
-    <ID>MagicNumber:NormalizingSvgDecoder.kt$4</ID>
-    <ID>MagicNumber:OnboardingScreen.kt$150</ID>
-    <ID>MagicNumber:OnboardingScreen.kt$220</ID>
-    <ID>MagicNumber:OnboardingScreen.kt$3</ID>
-    <ID>MagicNumber:OnboardingScreen.kt$4</ID>
-    <ID>MagicNumber:OnboardingScreen.kt$5</ID>
-    <ID>MagicNumber:ScrollingText.kt$1000</ID>
-    <ID>MagicNumber:VideoOverlayScreen.kt$1000L</ID>
-    <ID>MagicNumber:WidgetColorConfig.kt$0xFF000000L</ID>
-    <ID>MagicNumber:WidgetColorConfig.kt$0xFF2196F3L</ID>
-    <ID>MagicNumber:WidgetColorConfig.kt$0xFF4CAF50L</ID>
-    <ID>MagicNumber:WidgetColorConfig.kt$0xFF9C27B0L</ID>
-    <ID>MagicNumber:WidgetColorConfig.kt$0xFF9E9E9EL</ID>
-    <ID>MagicNumber:WidgetColorConfig.kt$0xFFF44336L</ID>
-    <ID>MagicNumber:WidgetColorConfig.kt$0xFFFFEB3BL</ID>
-    <ID>MagicNumber:WidgetColorConfig.kt$0xFFFFFF</ID>
-    <ID>MagicNumber:WidgetColorConfig.kt$0xFFFFFFFFL</ID>
-    <ID>MagicNumber:WidgetColorConfig.kt$16</ID>
-    <ID>MagicNumber:WidgetColorConfig.kt$6</ID>
     <ID>MaxLineLength:EsdeLogFileRepositoryTest.kt$EsdeLogFileRepositoryTest$fun</ID>
     <ID>MaximumLineLength:EsdeLogFileRepositoryTest.kt$EsdeLogFileRepositoryTest$ </ID>
     <ID>NestedBlockDepth:EsdeLogFileRepository.kt$EsdeLogFileRepository$private fun findEventsSinceLastAnchor( file: File, directionTracker: NavigationDirectionTracker, ): List&lt;EsdeEvent&gt;</ID>


### PR DESCRIPTION
## Summary
- Fixes all 37 remaining `MagicNumber` detekt baseline entries by extracting named constants.
- Notable fixes: color/animation-stop constants in `WidgetColorConfig.kt`/`AnimatedLogoImage.kt`; a shared dark-theme luminance threshold duplicated across `AppDock.kt`/`AppDrawer.kt`/`CornerButtonMetrics.kt`/`MusicControlsOverlay.kt` (kept as separate local constants per file rather than a cross-file extraction, to stay within this PR's scope); percent/index/duration constants across several data-layer repositories and UI files; and a list-based lookup replacing `OnboardingScreen.kt`'s `when`-mapped step ordinals (`OnboardingStep` is a sealed class with no built-in ordinal) - a genuine readability improvement, not just number-hiding.
- **Scope note**: surveyed the full ~191-entry Phase 5 backlog before starting. Most of what remains (`LongParameterList`, `TooManyFunctions`, `CyclomaticComplexMethod`, `LongMethod`, `EmptyFunctionBlock`) turned out to be DI-constructor/large-composable/test-fake cases rather than isolated bugs - the same shape of thing already tolerated for `SettingsViewModel`'s 60+ parameter constructor elsewhere in this codebase. Per discussion, those are left baselined as documented debt rather than forcing param-object wrappers or composable splits that would be real (and debatable) architectural changes, not cleanup.
- detekt baseline: **191 -> 154 entries**.

## Test plan
- [x] `ktlintCheck detekt testDebugUnitTest` all pass
- [x] On-device smoke test: Settings menu drill-down transitions, App Drawer/Dock settings (grid columns), theme-aware colors all render correctly