### PR TITLE
release-1.0.5

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -263,8 +263,8 @@ Track selection is always random — there's no separate shuffle toggle because 
 
 ### Videos aren't playing. How do I fix this?
 
-1. **Check the setting**: Settings → Video Playback → "Background Video" must be on (it's off by default)
-2. **Check the delay**: there's a configurable 0-10 second delay (default 3s) before playback starts — until then, the widget canvas underneath stays visible
+1. **Check for a Video widget**: video is a widget now, not a global setting — add a **Video** widget to the Game canvas (long-press → Widgets → Add Widget → Video). No Video widget placed means no video plays.
+2. **Check the Start Delay**: each Video widget has its own configurable 0-10 second delay before playback starts (0/"Off" by default) — until then, the widget canvas underneath stays visible
 3. **File format**: supported formats are MP4, MKV, AVI, WMV, MOV, WEBM, placed in each system's `videos/` media folder
 4. **Media folder**: verify Settings → Setup → Media folder is correct
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
   >
 </a>
 
-![Version](https://img.shields.io/badge/version-1.0.4-blue)
+![Version](https://img.shields.io/badge/version-1.0.5-blue)
 ![Android](https://img.shields.io/badge/Android-10%2B-green)
 
 ES-DE Companion is a companion application for [ES-DE](https://es-de.org) that enhances your gaming experience by transforming dual-screen Android devices into immersive retro gaming setups. The app displays beautiful game artwork, videos, and customizable overlay widgets on a secondary screen while you browse and play games in ES-DE.
@@ -45,7 +45,7 @@ _The companion screen automatically updates as you browse games in ES-DE, showin
 
 **Display Features:**
 - Real-time synchronization with ES-DE by reading its own `es_log.txt` directly — no scripts to install or maintain
-- Optional video playback while browsing games, with a configurable start delay and an audio toggle
+- Optional video playback while browsing games, as a placeable/resizable widget with a configurable start delay, loop, and audio toggle
 - Optional background music tied to what you're browsing, with volume ducking or pause while a video plays
 - System logo display (207 built-in logos + custom logo overrides)
 - Per-widget image/logo transitions, Logo Glint, and Pan & Zoom
@@ -57,7 +57,8 @@ _Create fully customizable overlay widgets to display game artwork - marquees, b
 
 **Widget Features:**
 - Two independent canvases — System View and Game View — each with their own widget layout
-- Up to 12 widget types per canvas: Marquee, Box Cover, 3D Box, Mix Image, Screenshot, Fan Art, Title Screen, Back Cover, Physical Media, System Logo, System Image, Description, Custom Image, and Color Background
+- 6 widget types on System View: System Logo, System Image, Random Game Fan Art, Random Game Screenshot, Custom Image, and Color Background
+- 16 widget types on Game View: Marquee, System Logo, System Image, Description, Rating, Box Cover, 3D Box, Mix Image, Screenshot, Fan Art, Title Screen, Back Cover, Physical Media, Custom Image, Color Background, and Video
 - Drag-and-drop positioning and resizing, snapped to a grid
 - Independent Left/Right/Top/Bottom resize handles with edge-snapping near the screen boundary
 - Layer ordering (move forward/backward)
@@ -82,6 +83,15 @@ _A full Android app launcher accessible from the companion screen, plus an optio
 - Same this-screen/other-screen launch preferences as the App Drawer
 - A pinnable App Drawer shortcut slot for one-tap drawer access alongside your apps
 
+### Game Launch Override
+
+_Automatically launch a specific app whenever ES-DE starts playing a game — a standalone emulator or launcher instead of ES-DE's own setup, on a per-system or per-game basis._
+
+**Game Launch Override Features:**
+- Per-system defaults and per-game overrides, browsed from a `gamelist.xml`-backed system/game picker in Settings
+- A per-game override can also be set to launch nothing, suppressing that system's default for just that one game
+- A single This Screen/Other Screen choice controls which display the launched app opens on
+
 ### Easy Setup
 
 _The built-in onboarding wizard guides you through configuration on first launch — no scripts to generate, just a few settings to confirm._
@@ -99,7 +109,8 @@ _The built-in onboarding wizard guides you through configuration on first launch
 _Up to four small buttons — one per screen corner — each independently configurable to whatever's most useful to you._
 
 **FAB Features:**
-- Six types per corner: Music Playback, Settings, Game Manual, App Drawer, a specific app you pick, or none
+- Nine types per corner: Music Playback, Settings, Game Manual, App Drawer, a specific app you pick, Clock, System Status (battery/wifi/bluetooth), Clock & System Status combined, or none
+- Music Playback and the Clock/System Status types are offered only in the two top corners
 - Music Playback can occupy either top corner (but only one at a time) — assigning it to the other top corner swaps the displaced button into place rather than discarding it
 - The Game Manual button appears automatically whenever the current game has a scanned manual, independent of the automatic "Manual" screen behavior setting
 - A custom-app button follows the same this-screen/other-screen launch preference (and indicator dot) as the App Drawer and App Dock
@@ -130,7 +141,7 @@ _ES-DE Companion checks GitHub for newer releases itself — no need to watch th
 _Export your entire configuration to a file, and bring it back with one restore — handy before a reinstall, a factory reset, or setting up a replacement device._
 
 **Backup Features:**
-- Settings → Setup → "Backup & Restore" exports every setting — Setup folder paths, UI/Video/Music/Other Settings, Floating Action Button assignments, App Drawer/Dock configuration and folders, and both widget canvases — to a single JSON file you choose the name and location for
+- Settings → Setup → "Backup & Restore" exports every setting — Setup folder paths, UI/Music/Other Settings, Floating Action Button assignments, Game Launch Override, App Drawer/Dock configuration and folders, both widget canvases (Video widget config included), and Thor Settings on supported hardware — to a single JSON file you choose the name and location for
 - Restoring reads a previously exported file back, with a confirmation step first since it overwrites every current setting
 - No extra permissions or setup required beyond picking where the file goes
 

--- a/USERGUIDE.md
+++ b/USERGUIDE.md
@@ -13,13 +13,14 @@ This comprehensive guide covers everything you need to know about ES-DE Companio
 5. [Widget Overlay System](#widget-overlay-system)
 6. [App Drawer](#app-drawer)
 7. [App Dock](#app-dock)
-8. [Video & Music](#video--music)
-9. [Settings Reference](#settings-reference)
-10. [File Structure](#file-structure)
-11. [How Log Events Work](#how-log-events-work)
-12. [In-App Updates](#in-app-updates)
-13. [Backup & Restore](#backup--restore)
-14. [Advanced Topics](#advanced-topics)
+8. [Game Launch Override](#game-launch-override)
+9. [Video & Music](#video--music)
+10. [Settings Reference](#settings-reference)
+11. [File Structure](#file-structure)
+12. [How Log Events Work](#how-log-events-work)
+13. [In-App Updates](#in-app-updates)
+14. [Backup & Restore](#backup--restore)
+15. [Advanced Topics](#advanced-topics)
 
 ---
 
@@ -174,7 +175,12 @@ ES-DE Companion can show up to four small floating buttons on the main screen �
 | **Manual** | Shown whenever the game currently playing, browsing, or displayed by the screensaver has a scanned manual PDF. Tapping opens it in the manual viewer — the same viewer the "Manual" Game Playing Screen Behavior option (see [Settings Reference](#settings-reference)) shows automatically, but on demand and independent of that setting. |
 | **App Drawer** | Opens the [App Drawer](#app-drawer), the same as swiping up. |
 | **App** | Launches a specific app you choose. See [Launching a Custom App](#launching-a-custom-app) below. |
+| **Clock** | Display-only — shows the current time, ticking every second, using your device's own 12h/24h format preference. Top corners only. |
+| **System Status** | Display-only — shows Battery (always, with charge tier and a charging bolt), Wifi, and Bluetooth. Wifi/Bluetooth icons only appear while actually connected; there's no "off" icon variant for either. Top corners only. |
+| **Clock & System Status** | Both of the above combined in one wide button. Top corners only. |
 | **None** | No button shown in that corner. |
+
+Clock, System Status, and Clock & System Status are variable-width (unlike every other FAB type, which is a fixed square) since their content isn't a fixed size. Showing Bluetooth status requires the Bluetooth permission on Android 12+; the first time you assign a System Status-family FAB, a one-time rationale dialog asks for it (declining just means the Bluetooth icon never appears).
 
 ### Defaults
 
@@ -230,7 +236,10 @@ While ES-DE Companion hasn't seen any activity yet (idle), no widget canvas is s
 | Widget Type | Description | Media Folder |
 |------------|-------------|--------------|
 | **Marquee** | Arcade-style marquee artwork | `marquees/` |
+| **System Logo** | The current game's system logo (same source as the System canvas widget) | (none — logo lookup only) |
+| **System Image** | The current game's system representative image (same source as the System canvas widget) | (none — image lookup only) |
 | **Description** | Scrollable text description, from `gamelist.xml` | (none — text only) |
+| **Rating** | The game's `<rating>` from `gamelist.xml`, shown as five filled/unfilled stars | (none — text/star only) |
 | **Box Cover** | Front cover of the game box | `covers/` |
 | **3D Box** | 3D perspective box art | `3dboxes/` |
 | **Mix Image** | ES-DE's composite image (screenshot + metadata) | `miximages/` |
@@ -241,6 +250,9 @@ While ES-DE Companion hasn't seen any activity yet (idle), no widget canvas is s
 | **Physical Media** | Disc/cartridge artwork | `physicalmedia/` |
 | **Custom Image** | An image you pick from your device | N/A |
 | **Color Background** | A solid color panel with adjustable transparency | N/A |
+| **Video** | The game's video, playing while browsing (never during gameplay) — see [Video Playback](#video-playback) | `videos/` |
+
+System Logo and System Image are offered on both canvases — the system a game belongs to is meaningful context either way.
 
 ### Per-Widget Configuration
 
@@ -255,6 +267,8 @@ Configuration options depend on the widget type, shown in this order in the Conf
 - **Blur** and **Darken** sliders (0-100% each) — every image-backed widget.
 - **Color Background** (its own widget type, no image options): 8 preset swatches or a free-form hex color, plus a **Transparency** slider (0-100%).
 - **Description** (its own widget type): **Text Size** (10-36sp), **Text Color**, **Background Color**, and **Background Transparency**.
+- **Rating** (its own widget type): filled/outline star colors, background color/transparency, and a **No Rating Behavior** choice (Hide, or show empty stars) for games with no `<rating>` at all.
+- **Video** (its own widget type, no image options): **Scale Mode** (Contain/Cover), **Pillarbox** (Contain only — black bars or transparent), **Audio** on/off, **Start Delay** (0-10s), **Loop** on/off, and **Render Above UI** — see [Video Playback](#video-playback).
 
 All of the above is set per widget instance, from that widget's own Configure Widget dialog — there's no global transitions/glint/pan-and-zoom setting in Settings. A freshly-added System Logo or Marquee widget starts with the Slide transition and Logo Glint on; a freshly-added System Image or Fan Art background starts with Pan & Zoom on and 10% darken.
 
@@ -372,18 +386,32 @@ The dock's transparency isn't a separate setting — it shares the same master "
 
 ---
 
+## Game Launch Override
+
+Automatically launch a specific app whenever ES-DE starts playing a game — useful for handing off to a standalone emulator or launcher instead of ES-DE's own RetroArch/core setup for particular systems or games.
+
+- Configured in **Settings → UI Settings → Game Launch Override**, which opens a browser of every system that has a `gamelist.xml` (the same source the Description widget reads from — not a full ES-DE library browser, just enough to assign overrides).
+- **System default**: pick an app for a whole system — every game in that system launches it unless a per-game override says otherwise.
+- **Per-game override**: drill into a system to pick an individual game and assign it its own app, overriding that system's default. An override can also be set to "nothing," which suppresses the system default for that one game rather than falling back to it.
+- **Display target**: a single global "This Screen" / "Other Screen" choice (default: This Screen) controls which display the launched app opens on — This Screen is Companion's own screen (temporarily replacing its UI there), Other Screen is whichever display ES-DE/the game itself is running on.
+- Nothing launches for a system/game with no override configured — there's no separate on/off toggle needed.
+
+---
+
 ## Video & Music
 
 ### Video Playback
 
-Optional video playback for the game you're currently browsing.
+Video is a **widget**, not a global setting — add a **Video** widget to the Game canvas (see [Widget Overlay System](#widget-overlay-system)) to enable it. There's no separate on/off toggle: no Video widget placed means no video plays.
 
-- **Off by default.**
 - Plays **only while browsing a specific game** — never during actual gameplay, never during the screensaver, and never while browsing systems.
-- **Video Start Delay**: 0-10 seconds before playback starts (default 3s). Until playback actually begins, the widget canvas underneath remains visible.
-- **Video Audio**: on/off toggle for whether the video plays with sound (default on).
+- **Start Delay**: 0-10 seconds before playback starts, shown as "Off" at 0 (the default for a freshly-added widget). Until playback actually begins, the widget canvas underneath remains visible.
+- **Audio**: on/off toggle for whether the video plays with sound (default on).
+- **Loop**: on/off toggle — repeats the video, or plays it once and holds on the final frame (default on).
+- **Scale Mode**: Contain (letterboxed) or Cover (crops to fill); Contain-only adds a **Pillarbox** choice (black bars or transparent).
+- **Render Above UI**: an opt-out per-widget toggle to draw this specific video above everything else (FABs, App Dock, App Drawer, dim/black screen covers) instead of at the normal widget-canvas layer.
 
-Configured in **Settings → Video Playback**.
+All of the above is configured per widget instance, from that Video widget's own Configure Widget dialog — see [Per-Widget Configuration](#per-widget-configuration).
 
 ### Background Music
 
@@ -425,11 +453,12 @@ Tapping this category in the Settings popup jumps straight to the widget editor 
 |---|---|---|---|
 | Theme | Segmented control | Auto / Light / Dark | Auto |
 | Overlay Opacity | Slider | 0-100% | 80% — applies to the App Drawer, App Dock, and other overlay surfaces |
+| Floating Action Buttons | Four dropdowns, one per corner | Music / Settings / Manual / App Drawer / App / Clock / System Status / Clock & System Status / None (Music/Clock/System Status/Clock & System Status offered only in the top corners) | Top Left: Music, Top Right: Settings, Bottom Left: None, Bottom Right: Manual |
+| Screensaver Screen Behavior | Dropdown | On / Dim / Off | On |
+| Screensaver Dimming Amount | Slider (shown only when Screensaver Screen Behavior is Dim) | 0-100% | 50% |
 | Game Playing Screen Behavior | Segmented control | On / Dim / Off / Manual | On |
 | Game Playing Dimming Amount | Slider (shown only when Game Playing Screen Behavior is Dim) | 0-100% | 50% |
-| Screensaver Screen Behavior | Segmented control | On / Dim / Off | On |
-| Screensaver Dimming Amount | Slider (shown only when Screensaver Screen Behavior is Dim) | 0-100% | 50% |
-| Floating Action Buttons | Four dropdowns, one per corner | Music / Settings / Manual / App Drawer / App / None | Top Left: Music, Top Right: Settings, Bottom Left: None, Bottom Right: Manual |
+| Game Launch Override | Opens the system/game browser, plus a This Screen/Other Screen display picker | See [Game Launch Override](#game-launch-override) | This Screen |
 
 `Screen Behavior` options: **On** leaves the screen as normal; **Dim** overlays a translucent black scrim (touches still pass through), with its darkness set independently by the matching Dimming Amount slider; **Off** shows an opaque black cover and blocks touches except a double-tap to restore (the same cover the manual double-tap-to-blank gesture uses — see [Screen Gestures](#screen-gestures)); **Manual** (Game Playing only) shows the game's manual PDF instead.
 
@@ -452,14 +481,6 @@ See [Floating Action Buttons](#floating-action-buttons) for what each corner opt
 `Sort folders on top of apps`: when on, folders are grouped ahead of all ungrouped apps; when off, folders and apps are interleaved into one alphabetical list by name/label. See [Folders](#folders).
 
 `Show Search Bar`: shows or hides the search field and Android/App Settings shortcut buttons above the drawer grid. Turning it off clears any in-progress search query. See [Using the App Drawer](#using-the-app-drawer).
-
-### Video Playback
-
-| Setting | Control | Options | Default |
-|---|---|---|---|
-| Background Video | Toggle | On/Off | Off |
-| Video Start Delay | Slider (shown only if enabled) | 0-10 seconds | 3 seconds |
-| Video Audio | Toggle (shown only if enabled) | On/Off | On |
 
 ### Background Music
 
@@ -604,10 +625,12 @@ Everything this app persists as a user setting:
 
 - Setup folder paths (ES-DE folder, Media folder, Custom System Images/Logos/Music folders)
 - UI Settings (theme, overlay opacity, Screen Behavior, Floating Action Button assignments)
-- Video Playback and Background Music settings
+- Background Music settings (Video is per-widget now, backed up as part of the widget canvases below)
 - Other Settings (Close Companion App on ES-DE Quit, Launch ES-DE on Companion App Start, Debug Logging)
 - App Drawer and Dock settings — hidden apps, grid columns, other-screen launch preferences, folders, and Dock configuration
+- Game Launch Override — system defaults, per-game overrides, and the This Screen/Other Screen display target
 - Both widget canvases (System View and Game View), including every placed widget and its per-widget configuration
+- Thor Settings, on supported hardware (AYN Thor)
 
 Not included: the onboarding-complete flag, the "what's new" last-seen-version marker, and other purely internal bookkeeping that isn't really a user setting.
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -26,8 +26,8 @@ android {
         applicationId = "com.esde.companion"
         minSdk = 29
         targetSdk = 35
-        versionCode = 30
-        versionName = "1.0.4"
+        versionCode = 33
+        versionName = "1.0.5"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/app/src/main/java/com/esde/companion/domain/model/GameLaunchDisplayTarget.kt
+++ b/app/src/main/java/com/esde/companion/domain/model/GameLaunchDisplayTarget.kt
@@ -4,9 +4,11 @@ package com.esde.companion.domain.model
  * Which display [com.esde.companion.data.gamelist.GameLaunchOverrideCoordinator] launches a
  * configured Game Launch Override app onto - a single global setting, not configurable per
  * system/game. [ThisScreen] launches on Companion's own screen (the historical, and still
- * default, behavior - see [AppLauncher][com.esde.companion.data.apps.AppLauncher]'s `displayId =
- * null`), temporarily replacing Companion's UI there. [OtherScreen] instead targets whichever
- * display Companion is *not* running on - the one ES-DE/the game itself is on - via
+ * default, behavior - via [CompanionDisplayHolder][com.esde.companion.data.apps.CompanionDisplayHolder]'s
+ * known display id, since the coordinator only holds an application Context, not one tied to any
+ * display - see [AppLauncher][com.esde.companion.data.apps.AppLauncher]), temporarily replacing
+ * Companion's UI there. [OtherScreen] instead targets whichever display Companion is *not*
+ * running on - the one ES-DE/the game itself is on - via
  * [SecondaryDisplayResolver][com.esde.companion.data.apps.SecondaryDisplayResolver].
  */
 enum class GameLaunchDisplayTarget {


### PR DESCRIPTION
Merges the 1.0.5 release branch: version bump to 1.0.5 (versionCode 33), the Launch App on Game Start (Game Launch Override) feature, and doc updates covering everything shipped since 1.0.4.