### PR TITLE
release-1.0.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
   >
 </a>
 
-![Version](https://img.shields.io/badge/version-1.0.5-blue)
+![Version](https://img.shields.io/badge/version-1.0.6-blue)
 ![Android](https://img.shields.io/badge/Android-10%2B-green)
 
 ES-DE Companion is a companion application for [ES-DE](https://es-de.org) that enhances your gaming experience by transforming dual-screen Android devices into immersive retro gaming setups. The app displays beautiful game artwork, videos, and customizable overlay widgets on a secondary screen while you browse and play games in ES-DE.
@@ -91,6 +91,8 @@ _Automatically launch a specific app whenever ES-DE starts playing a game — a 
 - Per-system defaults and per-game overrides, browsed from a `gamelist.xml`-backed system/game picker in Settings
 - A per-game override can also be set to launch nothing, suppressing that system's default for just that one game
 - A single This Screen/Other Screen choice controls which display the launched app opens on
+- Input focus automatically returns to the game once the launched app appears, so it doesn't get stuck on the wrong screen (Thor devices only)
+- Optional "Close App on Game End" toggle force-stops the launched app once the game ends (Thor devices only)
 
 ### Easy Setup
 

--- a/USERGUIDE.md
+++ b/USERGUIDE.md
@@ -394,6 +394,8 @@ Automatically launch a specific app whenever ES-DE starts playing a game — use
 - **System default**: pick an app for a whole system — every game in that system launches it unless a per-game override says otherwise.
 - **Per-game override**: drill into a system to pick an individual game and assign it its own app, overriding that system's default. An override can also be set to "nothing," which suppresses the system default for that one game rather than falling back to it.
 - **Display target**: a single global "This Screen" / "Other Screen" choice (default: This Screen) controls which display the launched app opens on — This Screen is Companion's own screen (temporarily replacing its UI there), Other Screen is whichever display ES-DE/the game itself is running on.
+- **Focus automatically returns to the game** once the launched app appears, on Ayn Thor devices — launching an app on either screen steals hardware-key/controller focus, so Companion hands it back once the launched app has actually finished loading. Best-effort and automatic; there's no toggle for it.
+- **Close App on Game End** (off by default, Thor devices only): force-stops the launched app once the triggering game ends, reusing the same mechanism as Thor Settings' Task Killer.
 - Nothing launches for a system/game with no override configured — there's no separate on/off toggle needed.
 
 ---
@@ -628,7 +630,7 @@ Everything this app persists as a user setting:
 - Background Music settings (Video is per-widget now, backed up as part of the widget canvases below)
 - Other Settings (Close Companion App on ES-DE Quit, Launch ES-DE on Companion App Start, Debug Logging)
 - App Drawer and Dock settings — hidden apps, grid columns, other-screen launch preferences, folders, and Dock configuration
-- Game Launch Override — system defaults, per-game overrides, and the This Screen/Other Screen display target
+- Game Launch Override — system defaults, per-game overrides, the This Screen/Other Screen display target, and the Close App on Game End toggle
 - Both widget canvases (System View and Game View), including every placed widget and its per-widget configuration
 - Thor Settings, on supported hardware (AYN Thor)
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -26,8 +26,8 @@ android {
         applicationId = "com.esde.companion"
         minSdk = 29
         targetSdk = 35
-        versionCode = 33
-        versionName = "1.0.5"
+        versionCode = 34
+        versionName = "1.0.6"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }


### PR DESCRIPTION
Merges the 1.0.6 release branch: version bump to 1.0.6 (versionCode 34), and doc updates covering everything shipped since 1.0.5 (focus automatically returning to the game after Launch App on Game Start, and the Close App on Game End toggle).