### PR TITLE
Pay down detekt baseline: singleton entries + disable Indentation rule

### DIFF
--- a/app/src/main/java/com/esde/companion/domain/model/RetroGameType.kt
+++ b/app/src/main/java/com/esde/companion/domain/model/RetroGameType.kt
@@ -27,7 +27,7 @@ fun String.retroGameTypes(): Set<RetroGameType> {
     val matched =
         RetroGameType.entries
             .filter { it.titleTag != null }
-            .filter { type -> contains(type.titleTag!!, ignoreCase = true) }
+            .filter { type -> type.titleTag?.let { tag -> contains(tag, ignoreCase = true) } == true }
             .toSet()
     return matched.ifEmpty { setOf(RetroGameType.Retail) }
 }

--- a/app/src/main/java/com/esde/companion/domain/parser/GameListParser.kt
+++ b/app/src/main/java/com/esde/companion/domain/parser/GameListParser.kt
@@ -55,13 +55,14 @@ object GameListParser {
         val document = GamelistXml.parseGameListDocument(content) ?: return null
 
         val gameNodes = document.getElementsByTagName("game")
-        for (index in 0 until gameNodes.length) {
-            val gameElement = gameNodes.item(index) as? Element ?: continue
-            val path = gameElement.firstTextOf("path") ?: continue
-            if (!romPath.matchesGamelistPath(path)) continue
-            return gameElement.firstTextOf(tagName)?.takeIf { it.isNotBlank() }
-        }
-        return null
+        return (0 until gameNodes.length).asSequence()
+            .mapNotNull { gameNodes.item(it) as? Element }
+            .firstOrNull { element ->
+                val path = element.firstTextOf("path")
+                path != null && romPath.matchesGamelistPath(path)
+            }
+            ?.firstTextOf(tagName)
+            ?.takeIf { it.isNotBlank() }
     }
 
     private const val DESCRIPTION_TAG = "desc"

--- a/app/src/test/java/com/esde/companion/data/log/EsdeLogFileRepositoryTest.kt
+++ b/app/src/test/java/com/esde/companion/data/log/EsdeLogFileRepositoryTest.kt
@@ -255,7 +255,7 @@ class EsdeLogFileRepositoryTest {
         }
 
     @Test
-    fun `a non-directional button press clears a prior direction, reproducing the real log excerpt's b-triggered system-select`() =
+    fun `a non-directional button press clears a prior direction, per the b-triggered system-select log excerpt`() =
         runTest {
             val logFile = tempFolder.newFile("es_log.txt")
             logFile.writeText(

--- a/config/detekt/baseline.xml
+++ b/config/detekt/baseline.xml
@@ -24,45 +24,6 @@
     <ID>EmptyFunctionBlock:SettingsViewModelTest.kt$SettingsViewModelTest.FakeAppDrawerSettingsRepository${}</ID>
     <ID>EmptyFunctionBlock:SettingsViewModelTest.kt$SettingsViewModelTest.FakeDockSettingsRepository${}</ID>
     <ID>EmptyFunctionBlock:SettingsViewModelTest.kt$SettingsViewModelTest.FakeOnboardingRepository${}</ID>
-    <ID>Indentation:AnimatedLogoImage.kt$ </ID>
-    <ID>Indentation:AppDock.kt$ </ID>
-    <ID>Indentation:AppDrawer.kt$ </ID>
-    <ID>Indentation:AppDrawerHandle.kt$ </ID>
-    <ID>Indentation:AppDrawerSettingsContent.kt$ </ID>
-    <ID>Indentation:CornerButtonMetrics.kt$ </ID>
-    <ID>Indentation:CrossfadeAsyncImage.kt$ </ID>
-    <ID>Indentation:DefaultWidgetLayouts.kt$ </ID>
-    <ID>Indentation:EditWidgetsOverlay.kt$ </ID>
-    <ID>Indentation:EditWidgetsViewModel.kt$EditWidgetsViewModel$ </ID>
-    <ID>Indentation:FileEsdeInstallationRepository.kt$FileEsdeInstallationRepository$ </ID>
-    <ID>Indentation:FolderContentsPopup.kt$ </ID>
-    <ID>Indentation:GameManualScreen.kt$ </ID>
-    <ID>Indentation:LongPressSettingsMenu.kt$ </ID>
-    <ID>Indentation:MainActivity.kt$MainActivity$ </ID>
-    <ID>Indentation:MainScreen.kt$ </ID>
-    <ID>Indentation:ManageAppsScreen.kt$ </ID>
-    <ID>Indentation:ManageAppsViewModelTest.kt$ManageAppsViewModelTest$ </ID>
-    <ID>Indentation:MusicPlaybackCoordinatorTest.kt$MusicPlaybackCoordinatorTest$ </ID>
-    <ID>Indentation:OnboardingScreen.kt$ </ID>
-    <ID>Indentation:OtherSettingsContent.kt$ </ID>
-    <ID>Indentation:PanZoomImage.kt$ </ID>
-    <ID>Indentation:ScrollingText.kt$ </ID>
-    <ID>Indentation:SettingsShared.kt$ </ID>
-    <ID>Indentation:SettingsViewModelTest.kt$SettingsViewModelTest$ </ID>
-    <ID>Indentation:SetupSettingsContent.kt$ </ID>
-    <ID>Indentation:SoundSettingsContent.kt$ </ID>
-    <ID>Indentation:ThorSettingsContent.kt$ </ID>
-    <ID>Indentation:Type.kt$ </ID>
-    <ID>Indentation:UISettingsContent.kt$ </ID>
-    <ID>Indentation:VideoPlaybackSettingsContent.kt$ </ID>
-    <ID>Indentation:WidgetCanvas.kt$ </ID>
-    <ID>Indentation:WidgetColorConfig.kt$ </ID>
-    <ID>Indentation:WidgetContentResolverTest.kt$WidgetContentResolverTest$ </ID>
-    <ID>Indentation:WidgetResizeGeometry.kt$ </ID>
-    <ID>Indentation:WidgetTextConfigControls.kt$ </ID>
-    <ID>Indentation:WidgetTypeDialogs.kt$ </ID>
-    <ID>Indentation:WidgetsSettingsContent.kt$ </ID>
-    <ID>Indentation:WidgetsViewModel.kt$WidgetsViewModel$ </ID>
     <ID>LongMethod:AnimatedLogoImage.kt$@Composable fun AnimatedLogoImage( model: Any?, contentDescription: String?, contentScale: ContentScale, mode: LogoTransitionMode, direction: NavigationDirection? = null, glintEnabled: Boolean = false, modifier: Modifier = Modifier, durationMillis: Int = 500, )</ID>
     <ID>LongMethod:AppDock.kt$@Composable fun AppDock( viewModel: AppDockViewModel, onOpenAppDrawer: () -&gt; Unit, modifier: Modifier = Modifier, )</ID>
     <ID>LongMethod:AppDock.kt$@Composable private fun DockItemMenu( expanded: Boolean, appLabel: String, isAppDrawerShortcut: Boolean, isOtherScreenPreferred: Boolean, isLeftmost: Boolean, isRightmost: Boolean, onDismiss: () -&gt; Unit, onLaunchThisScreen: () -&gt; Unit, onLaunchOtherScreen: () -&gt; Unit, onAppInfo: () -&gt; Unit, onMoveLeft: () -&gt; Unit, onMoveRight: () -&gt; Unit, onRemove: () -&gt; Unit, )</ID>
@@ -131,9 +92,6 @@
     <ID>LongParameterList:WidgetContentResolverTest.kt$WidgetContentResolverTest$( widgetType: WidgetType, systemLogoAssetPath: () -&gt; String? = { null }, customSystemLogoLookup: () -&gt; String? = { null }, customSystemImageLookup: () -&gt; String? = { null }, systemMediaLookup: (MediaType) -&gt; String? = { null }, gameMediaLookup: (MediaType) -&gt; String? = { null }, gameDescriptionLookup: () -&gt; String? = { null }, gameRatingLookup: () -&gt; Float? = { null }, fallbackBackgroundAssetPath: String? = "fallback.webp", systemNameLookup: () -&gt; String? = { null }, gameNameLookup: () -&gt; String? = { null }, videoLookup: () -&gt; String? = { null }, )</ID>
     <ID>LongParameterList:WidgetResizeGeometry.kt$( edge: ResizeEdge, widget: PlacedWidget, grid: GridDimensions, cellWidth: Dp, cellHeight: Dp, onResize: (widgetId: String, gridColumn: Int, gridRow: Int, columnSpan: Int, rowSpan: Int) -&gt; Unit, onDragStateChanged: (Boolean) -&gt; Unit, onDragEnd: () -&gt; Unit, modifier: Modifier = Modifier, )</ID>
     <ID>LongParameterList:WidgetsViewModel.kt$WidgetsViewModel$( observeConnectionState: ObserveConnectionStateUseCase, private val observeWidgetCanvas: ObserveWidgetCanvasUseCase, private val resolveGameMedia: ResolveGameMediaUseCase, private val resolveRandomSystemMedia: ResolveRandomSystemMediaUseCase, private val resolveGameDescription: ResolveGameDescriptionUseCase, private val resolveGameRating: ResolveGameRatingUseCase, private val resolveCustomSystemImage: ResolveCustomSystemImageUseCase, private val resolveCustomSystemLogo: ResolveCustomSystemLogoUseCase, private val resolveBundledSystemLogo: ResolveBundledSystemLogoUseCase, )</ID>
-    <ID>LoopWithTooManyJumpStatements:GameListParser.kt$GameListParser$for</ID>
-    <ID>MaxLineLength:EsdeLogFileRepositoryTest.kt$EsdeLogFileRepositoryTest$fun</ID>
-    <ID>MaximumLineLength:EsdeLogFileRepositoryTest.kt$EsdeLogFileRepositoryTest$ </ID>
     <ID>NestedBlockDepth:EsdeLogFileRepository.kt$EsdeLogFileRepository$private fun findEventsSinceLastAnchor( file: File, directionTracker: NavigationDirectionTracker, ): List&lt;EsdeEvent&gt;</ID>
     <ID>ReturnCount:EsdeEventParser.kt$EsdeEventParser$fun parseLine(rawLine: String): EsdeEvent?</ID>
     <ID>ReturnCount:EsdeLogFileRepository.kt$EsdeLogFileRepository$private fun findEventsSinceLastAnchor( file: File, directionTracker: NavigationDirectionTracker, ): List&lt;EsdeEvent&gt;</ID>

--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -1,3 +1,13 @@
 naming:
   FunctionNaming:
     ignoreAnnotated: ['Composable']
+
+formatting:
+  # Redundant with ktlintCheck, which is this project's actual formatting
+  # authority (see CLAUDE.md tech stack). The two disagree on continuation-line
+  # indentation for some wrapped Compose calls with no single config fix -
+  # ktlintFormat leaves these lines untouched, confirming ktlint already
+  # considers them correctly formatted. Not worth hand-reformatting files away
+  # from ktlint's accepted style just to satisfy a second, disagreeing rule.
+  Indentation:
+    active: false


### PR DESCRIPTION
## Summary
- Removes a reintroduced `!!` in `RetroGameType.retroGameTypes()` (CLAUDE.md forbids `!!` - the debt-paydown effort brought usages to zero, this one crept back in). Replaced with a safe-call filter.
- Fixes two of four remaining detekt baseline singleton findings: `LoopWithTooManyJumpStatements` (`GameListParser.findGameField`, refactored to a sequence-based lookup) and the `MaxLineLength`/`MaximumLineLength` pair (shortened one test name).
- Deliberately leaves `NestedBlockDepth` on `EsdeLogFileRepository.findEventsSinceLastAnchor` baselined - it's the anchor-replay core of the log pipeline, and its sibling `ReturnCount` finding on the same function was already accepted as debt by an earlier explicit decision. Not worth restructuring safety-critical pipeline code for a lint score.
- Disables detekt's `Indentation` rule and clears its 39 baseline entries. Un-baselined, that rule actually reports 958 individual line violations (the baseline collapses many-per-file into one entry each), and `ktlintFormat` - this project's real formatting authority - makes zero changes to any of them. That confirms these are cases where detekt's `Indentation` rule disagrees with formatting ktlint already accepts as correct, matching the "no single config change reconciles this" gotcha already documented in CLAUDE.md.

Net: detekt baseline 154 -> 112 entries.

## Test plan
- [x] `./gradlew testDebugUnitTest` - full suite passes
- [x] `./gradlew ktlintCheck detekt` - both pass clean against the updated baseline