### PR TITLE
Speed up Game Guides HTML viewer image loading

### DIFF
--- a/app/src/main/java/com/esde/companion/data/gameguides/GuideImageDimensionAnnotator.kt
+++ b/app/src/main/java/com/esde/companion/data/gameguides/GuideImageDimensionAnnotator.kt
@@ -1,0 +1,64 @@
+package com.esde.companion.data.gameguides
+
+import android.graphics.BitmapFactory
+import java.io.File
+
+private val IMG_TAG_REGEX = Regex("""<img\b[^>]*>""", RegexOption.IGNORE_CASE)
+private val SRC_ATTR_REGEX = Regex("""\bsrc\s*=\s*"([^"]*)"""", RegexOption.IGNORE_CASE)
+private val HAS_WIDTH_ATTR_REGEX = Regex("""\bwidth\s*=""", RegexOption.IGNORE_CASE)
+private val IMG_OPEN_TAG_REGEX = Regex("<img", RegexOption.IGNORE_CASE)
+
+/**
+ * Injects real `width`/`height` attributes into every `<img>` in [bodyHtml] whose dimensions can
+ * be resolved locally, so the browser reserves the correct layout space before the image has
+ * actually decoded - see `GameGuideHtmlViewer`'s kdoc for why this replaces waiting for images
+ * to finish loading before trusting `scrollHeight`/`scrollIntoView`. A tag that already has a
+ * `width` attribute is left untouched (idempotent, and forward-compatible if dimensions are ever
+ * also baked in at save time). A `src` that doesn't resolve to a real local file, or fails to
+ * decode, just leaves that one tag unmodified - graceful, per-image degradation, not a whole-page
+ * failure; the caller already tolerates some images not having known dimensions by falling back
+ * to its own layout-stability wait.
+ *
+ * [readImageDimensions] defaults to [readBitmapBounds] (real file IO) but is overridable so this
+ * function itself stays plain-Kotlin unit-testable without touching Android framework classes -
+ * see `GuideImageDimensionAnnotatorTest`.
+ */
+fun annotateImageDimensions(
+    bodyHtml: String,
+    mediaDirectoryPath: String,
+    readImageDimensions: (File) -> Pair<Int, Int>? = ::readBitmapBounds,
+): String =
+    IMG_TAG_REGEX.replace(bodyHtml) { match ->
+        val tag = match.value
+        if (HAS_WIDTH_ATTR_REGEX.containsMatchIn(tag)) {
+            tag
+        } else {
+            val src = SRC_ATTR_REGEX.find(tag)?.groupValues?.get(1)
+            val dimensions = src?.let { readImageDimensions(File(mediaDirectoryPath, it)) }
+            if (dimensions == null) {
+                tag
+            } else {
+                val (width, height) = dimensions
+                tag.replaceFirst(IMG_OPEN_TAG_REGEX, "<img width=\"$width\" height=\"$height\"")
+            }
+        }
+    }
+
+/**
+ * Header-only decode ([BitmapFactory.Options.inJustDecodeBounds]) - no pixel data is actually
+ * read, just the image container's declared dimensions, cheap enough to do for every image on a
+ * page load. Null on any failure (missing file, corrupt/unsupported format, ...).
+ *
+ * Not unit tested - real Android `BitmapFactory` calls aren't exercisable under this project's
+ * plain JVM unit tests (no Robolectric shadowing configured; the same gap `NativeImageDownloader`'s
+ * own `BitmapFactory` usage already has). [annotateImageDimensions]'s `readImageDimensions`
+ * parameter is what keeps the surrounding logic testable despite that.
+ */
+fun readBitmapBounds(file: File): Pair<Int, Int>? {
+    if (!file.isFile) return null
+    val options = BitmapFactory.Options().apply { inJustDecodeBounds = true }
+    BitmapFactory.decodeFile(file.path, options)
+    val width = options.outWidth
+    val height = options.outHeight
+    return if (width > 0 && height > 0) width to height else null
+}

--- a/app/src/main/java/com/esde/companion/ui/gameguides/GameGuideHtmlViewer.kt
+++ b/app/src/main/java/com/esde/companion/ui/gameguides/GameGuideHtmlViewer.kt
@@ -22,7 +22,9 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.viewinterop.AndroidView
+import com.esde.companion.data.gameguides.annotateImageDimensions
 import com.esde.companion.data.gameguides.writeViewerDocument
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.delay
@@ -30,6 +32,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.withContext
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import kotlin.coroutines.resume
@@ -43,12 +46,22 @@ private const val SCROLL_REPORT_THRESHOLD = 0.01f
 private const val SCROLL_INITIAL_SETTLE_MILLIS = 1_800L
 
 // Bounds how long a cross-page TOC jump waits for its target page to finish loading before
-// giving up and scrolling anyway (a same-page jump never waits at all - see the
-// scrollToAnchorId effect's kdoc). Generous relative to a real page load's own worst case
-// (loadAndAwaitFinished + awaitScrollableLayout), same "degrade, don't hang forever" principle
+// giving up and scrolling anyway. Generous relative to a real page load's own worst case
+// (loadAndAwaitStarted + awaitScrollableLayout), same "degrade, don't hang forever" principle
 // used throughout this viewer.
 private const val ANCHOR_WAIT_POLL_ATTEMPTS = 40
 private const val ANCHOR_WAIT_POLL_INTERVAL_MILLIS = 100L
+
+// Bounds awaitStableValue - same degrade-and-proceed principle as the other polls in this file.
+// annotateImageDimensions means layout is usually already stable within the first check or two;
+// a page with an image that couldn't be annotated (missing file, decode failure) just proceeds
+// anyway once this bound is hit, same fallback as before.
+private const val LAYOUT_STABILITY_POLL_ATTEMPTS = 40
+private const val LAYOUT_STABILITY_POLL_INTERVAL_MILLIS = 100L
+
+// Sub-pixel tolerance for awaitStableValue's "two consecutive reads agree" check - guards
+// against harmless floating-point jitter between reads rather than requiring bit-exact equality.
+private const val STABILITY_EPSILON_PX = 0.5f
 
 private fun backgroundColorInt(isDarkTheme: Boolean): Int =
     android.graphics.Color.parseColor(if (isDarkTheme) DARK_BACKGROUND_HEX else LIGHT_BACKGROUND_HEX)
@@ -77,6 +90,11 @@ data class HtmlViewerCallbacks(
     // the real time goes, and it previously showed nothing at all: the WebView just sat at
     // alpha 0 with no feedback.
     val onContentVisibleChanged: (Boolean) -> Unit = {},
+    // Same idea as onContentVisibleChanged, for the other gap that used to show nothing: a TOC
+    // jump on a page whose images are still loading in the background waits (see
+    // scrollToAnchorWhenReady) before it actually scrolls, and without this the content just sat
+    // still with no feedback, indistinguishable from the tap having done nothing at all.
+    val onAnchorJumpLoadingChanged: (Boolean) -> Unit = {},
 )
 
 /**
@@ -193,13 +211,18 @@ fun HtmlGuideContent(
     val latestConfig = rememberUpdatedState(config)
     LaunchedEffect(config.scrollToAnchorId) {
         val id = config.scrollToAnchorId ?: return@LaunchedEffect
-        scrollToAnchorWhenReady(id, webView) { loadedHtml == latestConfig.value.html && contentVisible }
+        callbacks.onAnchorJumpLoadingChanged(true)
+        try {
+            scrollToAnchorWhenReady(id, webView) { loadedHtml == latestConfig.value.html && contentVisible }
+        } finally {
+            callbacks.onAnchorJumpLoadingChanged(false)
+        }
         callbacks.onScrollToAnchorHandled()
     }
 
     // Waits out SCROLL_INITIAL_SETTLE_MILLIS before its first evaluation - this effect starts
     // concurrently with the page effect above that loads the page and restores
-    // initialScrollFraction (loadAndAwaitFinished -> awaitScrollableLayout, up to
+    // initialScrollFraction (loadAndAwaitStarted -> awaitScrollableLayout, up to
     // SCROLL_LAYOUT_POLL_ATTEMPTS * SCROLL_LAYOUT_POLL_INTERVAL_MILLIS -> the actual restore
     // script). Evaluating immediately raced that restore: it read the still-loading (or
     // previous) page's near-zero scroll position and reported it right away, silently
@@ -248,15 +271,27 @@ private suspend fun loadPageIntoWebView(
     // rendered) so a theme change while a guide is already open doesn't itself produce the
     // same white-flash-before-the-real-background gap this is fixing.
     webView.setBackgroundColor(backgroundColorInt(config.isDarkTheme))
-    val document = buildGuideHtmlDocument(config.html, config.isDarkTheme, config.fontScale)
+    // Real file IO (a bounds-only decode per <img>, see annotateImageDimensions' kdoc) - kept
+    // off whatever dispatcher this coroutine is already running on.
+    val annotatedHtml =
+        withContext(Dispatchers.IO) { annotateImageDimensions(config.html, config.mediaDirectoryPath) }
+    val document = buildGuideHtmlDocument(annotatedHtml, config.isDarkTheme, config.fontScale)
     // Pointed at this guide's own directory (not a generic cache/temp location) before the
     // write, so its relative image references (see NativeImageDownloader's kdoc) resolve as
     // plain sibling files once served back out through mediaLoader.
     mediaLoader.updateDirectory(config.mediaDirectoryPath)
     writeViewerDocument(config.mediaDirectoryPath, document)
-    loadAndAwaitFinished(webView, GUIDE_MEDIA_DOCUMENT_URL, mediaLoader, callbacks)
+    loadAndAwaitStarted(webView, GUIDE_MEDIA_DOCUMENT_URL, mediaLoader, callbacks)
     awaitScrollableLayout(webView)
     val targetFraction = liveFraction ?: config.initialScrollFraction
+    // Only a genuine mid-page restore needs a settled scrollHeight to compute an accurate
+    // target - landing at the top (the common case: a fresh open, or any page reached via
+    // next/previous) doesn't care what the final height turns out to be. annotateImageDimensions
+    // means scrollHeight is usually already correct the moment layout runs (no reflow left to
+    // wait out), so this typically resolves in a single check now - awaitStableScrollHeight is
+    // what still protects a page with an unresolved image (missing file, decode failure) from
+    // restoring against a height that's still growing.
+    if (targetFraction > 0f) awaitStableScrollHeight(webView)
     restoreScrollFraction(webView, targetFraction)
 }
 
@@ -264,12 +299,21 @@ private suspend fun loadPageIntoWebView(
  * The body of [HtmlGuideContent]'s scroll-to-anchor effect - pulled out purely to keep that
  * composable under detekt's length/complexity thresholds, not for reuse elsewhere.
  *
- * A same-page entry (see [GameGuideViewerScreen.onEntrySelected]) never needs this wait at all -
- * [webView] already has the right page loaded, so [isReady] is already true. A cross-page entry,
- * by contrast, races the page effect that's still loading the new page's content - this wait is
+ * A same-page entry (see [GameGuideViewerScreen.onEntrySelected]) skips the [isReady] wait -
+ * [webView] already has the right page loaded, so it's already true. A cross-page entry, by
+ * contrast, races the page effect that's still loading the new page's content - this wait is
  * what keeps this effect from evaluating `getElementById` before that element exists in the DOM
  * yet. [isReady] is polled fresh (not captured once) so it correctly observes the page effect's
  * own state changes as they happen.
+ *
+ * Both cases then await [awaitStableAnchorPosition] before the actual `scrollIntoView` - jumping
+ * straight there while the target's own position is still shifting (something above it is still
+ * reflowing) would compute its position too early and land short, then visibly drift as that
+ * settles. Narrower than [awaitStableScrollHeight] (only the target's own offset matters for a
+ * jump, not the whole page's final height) - something reflowing below the target doesn't affect
+ * where it sits, so waiting on that would only slow the jump down for no accuracy benefit.
+ * [annotateImageDimensions] means this is usually already stable on the first check (nothing left
+ * to reflow once every image's space is pre-reserved).
  */
 private suspend fun scrollToAnchorWhenReady(
     id: String,
@@ -282,6 +326,7 @@ private suspend fun scrollToAnchorWhenReady(
         attempts++
     }
     val encodedId = Json.encodeToString(id)
+    awaitStableAnchorPosition(webView, encodedId)
     // Not every guide's anchor markers use id="..." - confirmed on a real guide (Ori and the
     // Blind Forest, GameFAQs FAQ id 71410) whose own section markers are legacy
     // <a name="section13">, never matched by getElementById at all. Falling back to
@@ -293,6 +338,50 @@ private suspend fun scrollToAnchorWhenReady(
             "?.scrollIntoView({block: 'start'});",
         null,
     )
+}
+
+/**
+ * Polls [expression] twice, [LAYOUT_STABILITY_POLL_INTERVAL_MILLIS] apart, until two consecutive
+ * reads agree (within [STABILITY_EPSILON_PX], guarding against harmless sub-pixel jitter) or
+ * [LAYOUT_STABILITY_POLL_ATTEMPTS] is exhausted - "nothing is still reflowing" rather than "every
+ * image has finished decoding," which [annotateImageDimensions] means these two usually coincide
+ * on the very first check anyway. Shared shape for [awaitStableScrollHeight] and
+ * [awaitStableAnchorPosition], just against a different JS expression.
+ */
+private suspend fun awaitStableValue(
+    webView: WebView,
+    expression: String,
+) {
+    var previous = evaluateNumber(webView, expression)
+    repeat(LAYOUT_STABILITY_POLL_ATTEMPTS) {
+        delay(LAYOUT_STABILITY_POLL_INTERVAL_MILLIS)
+        val current = evaluateNumber(webView, expression)
+        if (current != null && previous != null && abs(current - previous) < STABILITY_EPSILON_PX) return
+        previous = current
+    }
+}
+
+/** See [loadPageIntoWebView]'s call site for why this replaced waiting on every image to decode. */
+private suspend fun awaitStableScrollHeight(webView: WebView) {
+    awaitStableValue(webView, "document.documentElement.scrollHeight")
+}
+
+/**
+ * A target that can't be found (a stale/mistyped anchor id) reads a constant `-1` on every
+ * check, which is trivially "stable" on the first comparison - a safe no-op, same as the
+ * `scrollIntoView` call after it already is.
+ */
+private suspend fun awaitStableAnchorPosition(
+    webView: WebView,
+    encodedId: String,
+) {
+    val expression =
+        "(function(){" +
+            "var t=document.getElementById($encodedId)||document.getElementsByName($encodedId)[0];" +
+            "if(!t)return -1;" +
+            "return t.getBoundingClientRect().top+window.pageYOffset;" +
+            "})()"
+    awaitStableValue(webView, expression)
 }
 
 /**
@@ -398,15 +487,27 @@ private fun buildGuideWebView(
 
 /**
  * Loads [url] (always [GUIDE_MEDIA_DOCUMENT_URL] in practice - see [HtmlGuideContent]) and
- * suspends until the WebView's own [WebViewClient.onPageFinished] fires, rather than racing it
+ * suspends until the WebView's own [WebViewClient.onPageStarted] fires, rather than racing it
  * with an immediate `evaluateJavascript` check right after [WebView.loadUrl] returns (which is
- * fire-and-forget - the load hasn't actually started rendering yet). Confirmed on-device via
- * temporary logging: the very first `document.documentElement.scrollHeight` poll routinely read
- * back a near-empty, not-yet-laid-out page (e.g. 8px) which still passed a bare "> 0" check, so
- * the scroll-position restore ran against a document that hadn't actually rendered its real
- * (thousands-of-pixels) content yet and always landed at the top - the same
- * [onPageFinished]-based pattern `GameFaqsBrowserBridge.navigateAndAwaitLoad` already uses for
- * exactly this reason.
+ * fire-and-forget - the load hasn't actually started rendering yet, so an eval right then risks
+ * reading a stale/blank state), and rather than [WebViewClient.onPageFinished] (this function's
+ * previous gate). `onPageFinished` turned out to correspond to the WebView's underlying
+ * network-idle signal, not the DOM `load` event - it doesn't fire until *every* resource request
+ * the WebView is aware of has settled, images included, regardless of whether those images are
+ * marked `loading="lazy"` (a `loading="lazy"` image is specifically excluded from delaying the
+ * spec `load` event, but that exclusion doesn't extend to whatever WebViewClient's own idle
+ * tracking considers "still loading"). Confirmed on-device via temporary timing logs: page turns
+ * on an image-heavy guide were still taking 1.5-2.5s to reveal despite [GuideHtmlDocumentBuilder]
+ * marking every image lazy - `onPageFinished` was waiting on exactly the images
+ * `BACKGROUND_IMAGE_LOADER_SCRIPT` deliberately re-fetches once `load` fires, which is real
+ * background network activity from the WebView's point of view even though it's scoped, by
+ * design, to run *after* the page has already visually settled. Gating on `onPageStarted`
+ * instead - which fires as soon as navigation to the new document begins, well before any
+ * resource (lazy or otherwise) has loaded - avoids that entirely; [awaitScrollableLayout]'s
+ * existing bounded retry-poll (added for a similar not-yet-laid-out-page race, back when this
+ * function still gated on `onPageFinished`) is what absorbs the small remaining gap between
+ * "navigation started" and "text content has actually flowed into the DOM enough to have a
+ * real scrollHeight" - unaffected by images either way, since text layout doesn't wait on them.
  *
  * `loadUrl` against [mediaLoader]'s virtual origin, not [WebView.loadDataWithBaseURL] (this
  * viewer's previous mechanism) or a real `file://` path (briefly tried in between - see
@@ -418,11 +519,11 @@ private fun buildGuideWebView(
  * no such second encoding pass, and lets sibling image files under the same directory resolve
  * as plain relative paths instead of needing to be embedded as base64 text in the first place.
  * This temporary client must keep the same [shouldInterceptRequest] delegation as the permanent
- * one [buildGuideWebView] installs - it fully replaces that client for the duration of this one
- * load, and the document's own embedded images request through the same interceptor as the
- * document itself.
+ * one [buildGuideWebView] installs - it fully replaces that client for the (now much shorter)
+ * duration of this one load, and the document's own embedded images request through the same
+ * interceptor as the document itself.
  */
-private suspend fun loadAndAwaitFinished(
+private suspend fun loadAndAwaitStarted(
     webView: WebView,
     url: String,
     mediaLoader: GuideMediaLoader,
@@ -434,17 +535,17 @@ private suspend fun loadAndAwaitFinished(
             webView.webViewClient =
                 object : WebViewClient() {
                     // Every other navigation is still unconditionally blocked (this temporary
-                    // client's whole job while a page is mid-load), but TAP_TOGGLE_URL must be
-                    // recognized here too, the same way the permanent client does once loaded -
-                    // otherwise a chrome-toggle tap made while a large/slow page is still
-                    // loading gets silently swallowed by this client's own blanket "return
-                    // true" for the entire duration of that load, no matter how early the tap-
-                    // toggle script itself attaches in the document. Confirmed on-device as the
-                    // actual cause of "tap to toggle doesn't work while the page is still
-                    // loading" surviving an earlier fix that only moved the script earlier in
-                    // the document - the script attaching earlier never mattered, since this
-                    // client (not the permanent one with the real TAP_TOGGLE_URL handling) is
-                    // what's installed for the entire load regardless.
+                    // client's whole job while this one load is in flight), but TAP_TOGGLE_URL
+                    // must be recognized here too, the same way the permanent client does once
+                    // loaded - otherwise a chrome-toggle tap made in the brief window before this
+                    // client hands back to the permanent one gets silently swallowed by this
+                    // client's own blanket "return true", no matter how early the tap-toggle
+                    // script itself attaches in the document. Confirmed on-device (back when this
+                    // window spanned the whole page load) as the actual cause of "tap to toggle
+                    // doesn't work while the page is still loading" surviving an earlier fix that
+                    // only moved the script earlier in the document - the script attaching
+                    // earlier never mattered, since this client (not the permanent one with the
+                    // real TAP_TOGGLE_URL handling) is what's installed regardless.
                     override fun shouldOverrideUrlLoading(
                         view: WebView,
                         request: WebResourceRequest,
@@ -458,9 +559,10 @@ private suspend fun loadAndAwaitFinished(
                         request: WebResourceRequest,
                     ): WebResourceResponse? = mediaLoader.intercept(request)
 
-                    override fun onPageFinished(
+                    override fun onPageStarted(
                         view: WebView,
                         url: String?,
+                        favicon: android.graphics.Bitmap?,
                     ) {
                         webView.webViewClient = originalClient
                         if (continuation.isActive) continuation.resume(Unit)
@@ -474,10 +576,11 @@ private suspend fun loadAndAwaitFinished(
 }
 
 /**
- * A secondary safety net after [loadAndAwaitFinished] - `onPageFinished` corresponds to the
- * page's load event, which in the vast majority of cases means layout has already run too,
- * but this gives a freshly-loaded, still-reflowing page a few more short polls to settle
- * before the scroll-position restore reads its final `scrollHeight`.
+ * A secondary safety net after [loadAndAwaitStarted] - unlike when this function was written
+ * (see [loadAndAwaitStarted]'s kdoc for why it moved off `onPageFinished`), the page has often
+ * barely begun laying out by this point, not merely still reflowing - this is what actually
+ * absorbs that gap via its own bounded poll before the scroll-position restore reads a final
+ * `scrollHeight`.
  */
 private suspend fun awaitScrollableLayout(webView: WebView) {
     repeat(SCROLL_LAYOUT_POLL_ATTEMPTS) {

--- a/app/src/main/java/com/esde/companion/ui/gameguides/GameGuideViewerContent.kt
+++ b/app/src/main/java/com/esde/companion/ui/gameguides/GameGuideViewerContent.kt
@@ -13,7 +13,10 @@ import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.unit.dp
@@ -109,6 +112,7 @@ data class GuideContentActions(
     val onToggleChrome: () -> Unit,
     val onInternalAnchorTapped: (fragment: String) -> Unit,
     val onContentVisibleChanged: (Boolean) -> Unit = {},
+    val onAnchorJumpLoadingChanged: (Boolean) -> Unit = {},
 )
 
 internal fun buildGuideContentState(
@@ -117,8 +121,11 @@ internal fun buildGuideContentState(
 ): GuideContentState {
     // Only the page the guide was actually resumed on gets its saved scroll fraction - any
     // other page (reached via next/previous or a table-of-contents jump) starts at the top,
-    // the same way opening a different chapter of a book would.
-    val isResumedPage = uiState.currentPageIndex == state.initialPageIndex
+    // the same way opening a different chapter of a book would. !resumeConsumed matters here,
+    // not just the index match on its own - once the reader has navigated away at all, paging
+    // back to that same index later is an ordinary page visit, not a resume, and should land at
+    // the top like any other page - see GuideViewerUiState.resumeConsumed's kdoc.
+    val isResumedPage = uiState.currentPageIndex == state.initialPageIndex && !uiState.resumeConsumed
     val initialScrollFraction = if (isResumedPage) state.initialScrollFraction else 0f
     return GuideContentState(
         currentPage = state.currentPageContent,
@@ -139,6 +146,7 @@ internal fun buildGuideContentActions(
     onScrollFractionChanged: (pageIndex: Int, fraction: Float) -> Unit,
     onInternalAnchorTapped: (fragment: String) -> Unit,
     onContentVisibleChanged: (Boolean) -> Unit = {},
+    onAnchorJumpLoadingChanged: (Boolean) -> Unit = {},
 ): GuideContentActions =
     GuideContentActions(
         onScrollFractionChanged = { fraction -> onScrollFractionChanged(uiState.currentPageIndex, fraction) },
@@ -151,7 +159,56 @@ internal fun buildGuideContentActions(
         onToggleChrome = { uiState.chromeVisible = !uiState.chromeVisible },
         onInternalAnchorTapped = onInternalAnchorTapped,
         onContentVisibleChanged = onContentVisibleChanged,
+        onAnchorJumpLoadingChanged = onAnchorJumpLoadingChanged,
     )
+
+internal data class GuideContentLoadingState(
+    val contentActions: GuideContentActions,
+    val indicators: GuideLoadingIndicators,
+)
+
+/**
+ * Owns the two loading signals [GuideContentWithLoadingOverlay] renders - pulled out of
+ * [GameGuideViewerScreen] purely to keep that composable under detekt's length threshold, not
+ * for reuse elsewhere.
+ */
+@Composable
+internal fun rememberGuideContentLoadingState(
+    state: GameGuidesUiState.Viewing,
+    uiState: GuideViewerUiState,
+    derived: ViewerDerivedState,
+    onScrollFractionChanged: (pageIndex: Int, fraction: Float) -> Unit,
+    onInternalAnchorTapped: (fragment: String) -> Unit,
+): GuideContentLoadingState {
+    // Resets to "not yet visible" on every genuine page change (keyed on currentPageIndex),
+    // but survives a same-page font/theme reload - HtmlGuideContent itself never drops
+    // contentVisible for that case either (see its own kdoc), so there's nothing to hide.
+    var htmlContentVisible by remember(uiState.currentPageIndex) { mutableStateOf(false) }
+    // Not keyed on currentPageIndex like htmlContentVisible - a same-page jump never changes
+    // that, and this needs to reset to false regardless of which anchor wait it was tracking.
+    var anchorJumpLoading by remember { mutableStateOf(false) }
+    val contentActions =
+        buildGuideContentActions(
+            uiState = uiState,
+            onScrollFractionChanged = onScrollFractionChanged,
+            onInternalAnchorTapped = onInternalAnchorTapped,
+            onContentVisibleChanged = { htmlContentVisible = it },
+            onAnchorJumpLoadingChanged = { anchorJumpLoading = it },
+        )
+    // Covers both loading phases where nothing valid is on screen yet: the disk read
+    // (state.isLoadingContent) and, for an HTML guide, the WebView's own render phase (document
+    // write/load/scroll-restore) that follows it - previously that second phase showed nothing
+    // at all on an image-heavy page. anchorJumpLoading is deliberately NOT folded in here - a
+    // same-page TOC jump has a fully valid, already-visible page underneath it, so covering that
+    // with this opaque full-screen spinner (built for "nothing to show yet") would hide content
+    // the user was already reading; see the small corner indicator in
+    // GuideContentWithLoadingOverlay instead.
+    val showLoadingIndicator = state.isLoadingContent || (derived.isHtml && !htmlContentVisible)
+    return GuideContentLoadingState(
+        contentActions = contentActions,
+        indicators = GuideLoadingIndicators(showFullScreen = showLoadingIndicator, showAnchorJump = anchorJumpLoading),
+    )
+}
 
 @Composable
 fun GuideContentArea(
@@ -198,6 +255,7 @@ fun GuideContentArea(
                     onTap = actions.onToggleChrome,
                     onInternalAnchorTapped = actions.onInternalAnchorTapped,
                     onContentVisibleChanged = actions.onContentVisibleChanged,
+                    onAnchorJumpLoadingChanged = actions.onAnchorJumpLoadingChanged,
                 )
             HtmlGuideContent(config = htmlConfig, callbacks = htmlCallbacks)
         } else {

--- a/app/src/main/java/com/esde/companion/ui/gameguides/GameGuideViewerScreen.kt
+++ b/app/src/main/java/com/esde/companion/ui/gameguides/GameGuideViewerScreen.kt
@@ -8,6 +8,9 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
@@ -19,6 +22,8 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.unit.dp
 import com.esde.companion.domain.model.GameGuideDisplayPreferences
 import com.esde.companion.domain.model.GuideTocEntry
 
@@ -89,8 +94,14 @@ private fun buildHeaderActions(
         },
         onShowToc = { uiState.showToc = true },
         onClose = onClose,
-        onPreviousPage = { uiState.currentPageIndex = (uiState.currentPageIndex - 1).coerceAtLeast(0) },
-        onNextPage = { uiState.currentPageIndex = (uiState.currentPageIndex + 1).coerceAtMost(lastPageIndex) },
+        onPreviousPage = {
+            uiState.resumeConsumed = true
+            uiState.currentPageIndex = (uiState.currentPageIndex - 1).coerceAtLeast(0)
+        },
+        onNextPage = {
+            uiState.resumeConsumed = true
+            uiState.currentPageIndex = (uiState.currentPageIndex + 1).coerceAtMost(lastPageIndex)
+        },
     )
 }
 
@@ -117,6 +128,7 @@ private fun onInternalAnchorTapped(
         uiState.scrollToAnchorId = fragment
     } else {
         uiState.pendingAnchorId = fragment
+        uiState.resumeConsumed = true
         uiState.currentPageIndex = targetPageIndex
     }
 }
@@ -264,6 +276,7 @@ fun GameGuideViewerScreen(
                 entry.anchorId?.let { uiState.scrollToAnchorId = it }
             } else {
                 entry.anchorId?.let { uiState.pendingAnchorId = it }
+                uiState.resumeConsumed = true
                 uiState.currentPageIndex = targetPageIndex
             }
         } else {
@@ -275,21 +288,14 @@ fun GameGuideViewerScreen(
     val headerActions =
         buildHeaderActions(state, uiState, derived, actions.onDisplayPreferencesChanged, actions.onClose)
     val contentState = buildGuideContentState(state, uiState)
-    // Resets to "not yet visible" on every genuine page change (keyed on currentPageIndex),
-    // but survives a same-page font/theme reload - HtmlGuideContent itself never drops
-    // contentVisible for that case either (see its own kdoc), so there's nothing to hide.
-    var htmlContentVisible by remember(uiState.currentPageIndex) { mutableStateOf(false) }
-    val contentActions =
-        buildGuideContentActions(
+    val loadingState =
+        rememberGuideContentLoadingState(
+            state = state,
             uiState = uiState,
+            derived = derived,
             onScrollFractionChanged = actions.onScrollFractionChanged,
             onInternalAnchorTapped = { fragment -> onInternalAnchorTapped(fragment, state, uiState, lastPageIndex) },
-            onContentVisibleChanged = { htmlContentVisible = it },
         )
-    // Covers both loading phases: the disk read (state.isLoadingContent) and, for an HTML
-    // guide, the WebView's own render phase (document write/load/scroll-restore) that follows
-    // it - previously that second phase showed nothing at all on an image-heavy page.
-    val showLoadingIndicator = state.isLoadingContent || (derived.isHtml && !htmlContentVisible)
 
     // AnimatedVisibility, not a plain if - the underlying reliability issue that motivated
     // *not* animating this (see git history: overlay/layer-toggle attempts, all reverted) has
@@ -306,8 +312,8 @@ fun GameGuideViewerScreen(
             GuideContentWithLoadingOverlay(
                 derived = derived,
                 contentState = contentState,
-                contentActions = contentActions,
-                showLoadingIndicator = showLoadingIndicator,
+                contentActions = loadingState.contentActions,
+                indicators = loadingState.indicators,
                 modifier = Modifier.weight(1f),
             )
             AnimatedVisibility(
@@ -335,20 +341,31 @@ fun GameGuideViewerScreen(
 }
 
 /**
- * [GuideContentArea] stays mounted regardless of [showLoadingIndicator] (rather than being
- * swapped out while true) so [HtmlGuideContent]'s own content-visible effect can actually run
- * and report back once ready - see [GameGuideViewerScreen]'s `htmlContentVisible`/
- * `showLoadingIndicator` kdoc for why. The spinner overlay just covers whatever's underneath
- * (a blank first page, or the previous page for the one frame before its own `contentVisible`
- * drops back to false) with a solid background until then, extracted here purely to keep
- * [GameGuideViewerScreen] itself under detekt's length/complexity thresholds.
+ * The two independent loading signals [GuideContentWithLoadingOverlay] renders - bundled into
+ * one type purely to keep that composable's own parameter count under detekt's threshold, not
+ * because the two are conceptually linked (see their own call-site kdocs for why they're
+ * deliberately rendered differently).
+ */
+internal data class GuideLoadingIndicators(
+    val showFullScreen: Boolean,
+    val showAnchorJump: Boolean,
+)
+
+/**
+ * [GuideContentArea] stays mounted regardless of [GuideLoadingIndicators.showFullScreen]
+ * (rather than being swapped out while true) so [HtmlGuideContent]'s own content-visible effect
+ * can actually run and report back once ready - see [rememberGuideContentLoadingState]'s kdoc
+ * for why. The spinner overlay just covers whatever's underneath (a blank first page, or the
+ * previous page for the one frame before its own `contentVisible` drops back to false) with a
+ * solid background until then, extracted here purely to keep [GameGuideViewerScreen] itself
+ * under detekt's length/complexity thresholds.
  */
 @Composable
 private fun GuideContentWithLoadingOverlay(
     derived: ViewerDerivedState,
     contentState: GuideContentState,
     contentActions: GuideContentActions,
-    showLoadingIndicator: Boolean,
+    indicators: GuideLoadingIndicators,
     modifier: Modifier = Modifier,
 ) {
     Box(modifier = modifier.fillMaxSize()) {
@@ -360,12 +377,33 @@ private fun GuideContentWithLoadingOverlay(
         )
         // A pure Compose overlay Box - never touches the WebView's own bounds/sizing, so
         // (unlike the chrome header/footer toggle) fading it carries none of that risk.
-        AnimatedVisibility(visible = showLoadingIndicator, enter = fadeIn(), exit = fadeOut()) {
+        AnimatedVisibility(visible = indicators.showFullScreen, enter = fadeIn(), exit = fadeOut()) {
             Box(
                 modifier = Modifier.fillMaxSize().background(MaterialTheme.colorScheme.background),
                 contentAlignment = Alignment.Center,
             ) {
                 CircularProgressIndicator()
+            }
+        }
+        // Deliberately small and non-obscuring, unlike showFullScreen's overlay above - a
+        // same-page TOC jump has a fully valid page already on screen (just about to scroll
+        // once its target's images finish loading), so covering it entirely would hide content
+        // the user was already reading instead of just signaling a wait.
+        AnimatedVisibility(
+            visible = indicators.showAnchorJump,
+            enter = fadeIn(),
+            exit = fadeOut(),
+            modifier = Modifier.align(Alignment.TopEnd).padding(16.dp),
+        ) {
+            Box(
+                modifier =
+                    Modifier
+                        .size(36.dp)
+                        .clip(CircleShape)
+                        .background(MaterialTheme.colorScheme.surfaceVariant),
+                contentAlignment = Alignment.Center,
+            ) {
+                CircularProgressIndicator(modifier = Modifier.size(20.dp), strokeWidth = 2.dp)
             }
         }
     }

--- a/app/src/main/java/com/esde/companion/ui/gameguides/GuideHtmlDocumentBuilder.kt
+++ b/app/src/main/java/com/esde/companion/ui/gameguides/GuideHtmlDocumentBuilder.kt
@@ -40,6 +40,57 @@ private const val TAP_TOGGLE_SCRIPT =
     </script>
     """
 
+// Only <img ...> tags, not the rest of the markup - a loose ">"-based regex is good enough here
+// since this is already best-effort scraped-content processing (same spirit as
+// GuidePageContentProcessor's MAX_EMBEDDED_IMAGES handling), not a real HTML parser.
+private val IMG_TAG_REGEX = Regex("""<img\b[^>]*>""", RegexOption.IGNORE_CASE)
+private val EXISTING_LOADING_ATTR_REGEX = Regex("""\s+loading\s*=\s*"[^"]*"""", RegexOption.IGNORE_CASE)
+private val IMG_OPEN_TAG_REGEX = Regex("<img", RegexOption.IGNORE_CASE)
+
+/**
+ * Marks every `<img>` in [bodyHtml] `loading="lazy"` (normalizing away any conflicting attribute
+ * a scraped source page already carried) so the very first paint only has to decode whatever is
+ * on-screen, not the whole page - [BACKGROUND_IMAGE_LOADER_SCRIPT] is what keeps every other
+ * image loading anyway, just without blocking that first paint. See this file's kdoc on
+ * [buildGuideHtmlDocument] for the full reasoning.
+ */
+internal fun applyLazyImageLoading(bodyHtml: String): String =
+    IMG_TAG_REGEX.replace(bodyHtml) { match ->
+        val stripped = match.value.replace(EXISTING_LOADING_ATTR_REGEX, "")
+        stripped.replaceFirst(IMG_OPEN_TAG_REGEX, "<img loading=\"lazy\"")
+    }
+
+// Placed AFTER bodyHtml (unlike TAP_TOGGLE_SCRIPT), same spot as CLASHING_INLINE_COLOR_FIX_SCRIPT
+// below - it needs every <img> already parsed into the DOM to select them, not just document.body
+// to exist.
+//
+// The promotion to eager is deliberately deferred to the window 'load' event, not run
+// immediately - a loading="lazy" image is specifically excluded from delaying that event (the
+// whole reason the attribute exists), but an ordinary eager <img> is NOT, so flipping every
+// image back to eager before 'load' fires undoes the deferral entirely: WebViewClient's
+// onPageFinished (what loadAndAwaitStarted used to await, back when it was called
+// loadAndAwaitFinished) fires at essentially the same point as 'load', so this app would end up
+// waiting for every image again regardless of the lazy attribute - confirmed on-device as page
+// turns still being slow to reveal despite it. Waiting for 'load' first means the page has
+// already finished loading (and this app has already revealed it) before this script starts
+// pulling every remaining image in - true background loading, not just a relabeled eager load.
+// No completion flag to report back here (an earlier version had one) - GameGuideHtmlViewer no
+// longer waits on decode completion for anything; see annotateImageDimensions'/
+// awaitStableScrollHeight's kdocs for why layout correctness no longer depends on it.
+private const val BACKGROUND_IMAGE_LOADER_SCRIPT =
+    """
+    <script>
+    (function() {
+        var imgs = document.querySelectorAll('img[loading="lazy"]');
+        window.addEventListener('load', function() {
+            for (var i = 0; i < imgs.length; i++) {
+                imgs[i].loading = 'eager';
+            }
+        });
+    })();
+    </script>
+    """
+
 /**
  * Wraps a saved in-line HTML guide's bare content markup (just the body of `#faqwrap`, no
  * `<html>`/`<head>`/stylesheet of its own - GameFAQs' own CSS never shipped with it) in a
@@ -47,6 +98,19 @@ private const val TAP_TOGGLE_SCRIPT =
  * unstyled browser-default markup - GameFAQs' own site classes on this content expect a
  * stylesheet this app never downloaded, so this targets plain tag selectors instead of
  * trying to reproduce their exact class names.
+ *
+ * Every `<img>` is also marked `loading="lazy"` ([applyLazyImageLoading]) and
+ * [BACKGROUND_IMAGE_LOADER_SCRIPT] is appended - confirmed on-device that an image-heavy guide
+ * page was slow to open when every image loaded eagerly upfront. First paint now only waits on
+ * whatever's on-screen; everything else keeps loading in the background regardless of scroll
+ * position (these are local files, not network fetches, so that's typically fast). [bodyHtml] is
+ * expected to already have real `width`/`height` attributes baked into its `<img>` tags where
+ * they could be resolved (see `data/gameguides/GuideImageDimensionAnnotator.kt`, applied by the
+ * caller before this function runs) - that, not waiting for images to decode, is what keeps a
+ * position-critical action (restoring a saved scroll position, a TOC jump) accurate despite
+ * images still loading in the background; see
+ * [com.esde.companion.ui.gameguides.GameGuideHtmlViewer]'s `awaitStableScrollHeight`/
+ * `awaitStableAnchorPosition`.
  */
 internal fun buildGuideHtmlDocument(
     bodyHtml: String,
@@ -73,8 +137,9 @@ internal fun buildGuideHtmlDocument(
         pre { white-space: pre-wrap; }
         """.trimIndent()
     val colorFixScript = buildClashingInlineColorFixScript(isDarkTheme, foreground)
-    return "<html><head><meta charset=\"utf-8\"><style>$css</style></head>" +
-        "<body>${TAP_TOGGLE_SCRIPT.trimIndent()}$bodyHtml$colorFixScript</body></html>"
+    val lazyBodyHtml = applyLazyImageLoading(bodyHtml)
+    val body = "${TAP_TOGGLE_SCRIPT.trimIndent()}$lazyBodyHtml$BACKGROUND_IMAGE_LOADER_SCRIPT$colorFixScript"
+    return "<html><head><meta charset=\"utf-8\"><style>$css</style></head><body>$body</body></html>"
 }
 
 private const val CLASH_PATTERN_BLACK = """^rgba?\(0,\s*0,\s*0(,\s*1)?\)$"""

--- a/app/src/main/java/com/esde/companion/ui/gameguides/GuideViewerUiState.kt
+++ b/app/src/main/java/com/esde/companion/ui/gameguides/GuideViewerUiState.kt
@@ -45,4 +45,13 @@ internal class GuideViewerUiState(initialPageIndex: Int) {
     var pendingAnchorId: String? by mutableStateOf(null)
     var currentPageIndex: Int by mutableIntStateOf(initialPageIndex)
     var chromeVisible: Boolean by mutableStateOf(true)
+
+    // Set true by every real page navigation (next/previous, an in-content link, a TOC jump -
+    // see GameGuideViewerScreen's currentPageIndex mutation sites). buildGuideContentState's
+    // isResumedPage check needs this, not just "currentPageIndex == initialPageIndex" - without
+    // it, navigating away from the resumed page and later paging back to that same index looked
+    // indistinguishable from the original resume, and silently re-applied the old saved scroll
+    // fraction instead of landing at the top like any other page-turn (confirmed on-device: this
+    // is the actual bug, not a coincidence of which page happens to match).
+    var resumeConsumed: Boolean by mutableStateOf(false)
 }

--- a/app/src/test/java/com/esde/companion/data/gameguides/GuideImageDimensionAnnotatorTest.kt
+++ b/app/src/test/java/com/esde/companion/data/gameguides/GuideImageDimensionAnnotatorTest.kt
@@ -1,0 +1,76 @@
+package com.esde.companion.data.gameguides
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import java.io.File
+
+class GuideImageDimensionAnnotatorTest {
+    @Test
+    fun `injects width and height when dimensions resolve`() {
+        val result =
+            annotateImageDimensions(
+                bodyHtml = """<img src="images/p0_0.jpg">""",
+                mediaDirectoryPath = "/guides/g1",
+            ) { 1080 to 720 }
+
+        assertEquals("""<img width="1080" height="720" src="images/p0_0.jpg">""", result)
+    }
+
+    @Test
+    fun `leaves a tag that already has width untouched`() {
+        val body = """<img width="640" src="images/p0_0.jpg">"""
+
+        val result = annotateImageDimensions(body, "/guides/g1") { 1080 to 720 }
+
+        assertEquals(body, result)
+    }
+
+    @Test
+    fun `leaves a tag untouched when dimensions can't be resolved`() {
+        val body = """<img src="images/missing.jpg">"""
+
+        val result = annotateImageDimensions(body, "/guides/g1") { null }
+
+        assertEquals(body, result)
+    }
+
+    @Test
+    fun `resolves multiple images independently`() {
+        val body = """<p>Text</p><img src="images/a.jpg"><p>More</p><img src="images/b.jpg">"""
+
+        val result =
+            annotateImageDimensions(body, "/guides/g1") { file ->
+                when (file.name) {
+                    "a.jpg" -> 100 to 200
+                    "b.jpg" -> 300 to 400
+                    else -> null
+                }
+            }
+
+        val expected =
+            """<p>Text</p><img width="100" height="200" src="images/a.jpg">""" +
+                """<p>More</p><img width="300" height="400" src="images/b.jpg">"""
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun `passes the resolved local file path to the dimension reader`() {
+        var receivedPath: String? = null
+
+        annotateImageDimensions("""<img src="images/p0_0.jpg">""", "/guides/g1") { file ->
+            receivedPath = file.path
+            null
+        }
+
+        assertEquals(File("/guides/g1", "images/p0_0.jpg").path, receivedPath)
+    }
+
+    @Test
+    fun `leaves a body with no images untouched`() {
+        val body = "<p>Just text, no images.</p>"
+
+        val result = annotateImageDimensions(body, "/guides/g1") { 1080 to 720 }
+
+        assertEquals(body, result)
+    }
+}

--- a/app/src/test/java/com/esde/companion/ui/gameguides/GuideHtmlDocumentBuilderTest.kt
+++ b/app/src/test/java/com/esde/companion/ui/gameguides/GuideHtmlDocumentBuilderTest.kt
@@ -1,0 +1,61 @@
+package com.esde.companion.ui.gameguides
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class GuideHtmlDocumentBuilderTest {
+    @Test
+    fun `applyLazyImageLoading adds loading lazy to a plain img tag`() {
+        val result = applyLazyImageLoading("""<img src="p1_0.jpg">""")
+
+        assertEquals("""<img loading="lazy" src="p1_0.jpg">""", result)
+    }
+
+    @Test
+    fun `applyLazyImageLoading preserves other attributes`() {
+        val result = applyLazyImageLoading("""<img src="p1_0.jpg" alt="Screenshot" width="640">""")
+
+        assertEquals("""<img loading="lazy" src="p1_0.jpg" alt="Screenshot" width="640">""", result)
+    }
+
+    @Test
+    fun `applyLazyImageLoading replaces a pre-existing loading attribute rather than duplicating it`() {
+        val result = applyLazyImageLoading("""<img loading="eager" src="p1_0.jpg">""")
+
+        assertEquals("""<img loading="lazy" src="p1_0.jpg">""", result)
+        assertEquals(1, Regex("loading=").findAll(result).count())
+    }
+
+    @Test
+    fun `applyLazyImageLoading handles multiple images in one body`() {
+        val body = """<p>Text</p><img src="a.jpg"><p>More</p><img src="b.jpg">"""
+        val expected = """<p>Text</p><img loading="lazy" src="a.jpg"><p>More</p><img loading="lazy" src="b.jpg">"""
+
+        assertEquals(expected, applyLazyImageLoading(body))
+    }
+
+    @Test
+    fun `applyLazyImageLoading leaves body with no images untouched`() {
+        val body = "<p>Just text, no images.</p>"
+
+        assertEquals(body, applyLazyImageLoading(body))
+    }
+
+    @Test
+    fun `buildGuideHtmlDocument marks images lazy and includes the background loader script`() {
+        val document = buildGuideHtmlDocument("""<img src="p1_0.jpg">""", isDarkTheme = false, fontScale = 1f)
+
+        assertTrue(document.contains("""<img loading="lazy" src="p1_0.jpg">"""))
+        assertTrue(document.contains("""querySelectorAll('img[loading="lazy"]')"""))
+    }
+
+    @Test
+    fun `buildGuideHtmlDocument still includes the loader script for an image-free body`() {
+        val document = buildGuideHtmlDocument("<p>Just text.</p>", isDarkTheme = true, fontScale = 1f)
+
+        assertFalse(document.contains("<img"))
+        assertTrue(document.contains("""querySelectorAll('img[loading="lazy"]')"""))
+    }
+}


### PR DESCRIPTION
## Summary
- Image-heavy guide pages were slow to open because every image loaded eagerly and blocked the WebView's `onPageFinished` signal this app waited on before revealing anything. Marking images `loading="lazy"` alone didn't fix it — `onPageFinished` tracks network-idle state, not the DOM `load` event, so it still waited on every image; fixed by gating the reveal on `onPageStarted` instead.
- For scroll-position restore and TOC jumps, replaced waiting on images to fully decode with reading each image's real width/height up front (a cheap header-only file read), so the browser reserves the correct layout space immediately regardless of decode timing. A small corner spinner covers the rare remaining case where dimensions couldn't be resolved.
- Fixes a page-turn bug where navigating away from a guide's resumed page and later paging back to that same page index re-applied the original saved scroll position instead of landing at the top like any other page visit.

## Test plan
- [x] `./gradlew testDebugUnitTest ktlintCheck detekt assembleDebug` all green
- [x] Verified on-device (AYN Thor) on a real 20-page image-heavy downloaded guide: fast page turns, accurate same-page and cross-page TOC jumps, accurate resume-position restore, and the resumed-page/page-turn-back bug fix